### PR TITLE
Add Docker install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ The Philips Hue app should be able to find it on your network!
 ### Docker
 
 > [!WARNING]
-> Docker support just recently got [merged](https://github.com/chrivers/bifrost/pull/2) to this project. It is not optimal yet and there are no prebuilt images (yet). If you encounter any bugs or have suggestions, feel free to leave your feedback [here](#problems-questions-feedback).
+> Docker support was [merged recently](https://github.com/chrivers/bifrost/pull/2).
+> If you encounter any bugs, or have suggestions, feel free to leave your feedback [here](#problems-questions-feedback).
 
 To install Bifrost with Docker, you will need the following:
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,20 @@ might like to read the [comparison with DiyHue](doc/comparison-with-diyhue.md).
 
 ## Installation guide
 
-To install Bifrost, you will need the following:
+There are currently two ways you can install Bifrost.
 
- 1. The rust language toolchain (https://rustup.rs/)
- 2. At least one zigbee2mqtt server to connect to
- 3. The MAC address of the network interface you want to run the server on
+1.  [Install manualy](#manual) from source (for now, this is the preferred method)
+2.  [Install it via Docker](#docker) (still WIP, some aspects may not be optimal for now)
+
+When you have these things available, you can download
+
+### Manual
+
+To install Bifrost from source, you will need the following:
+
+1.  The rust language toolchain (https://rustup.rs/)
+2.  At least one zigbee2mqtt server to connect to
+3.  The MAC address of the network interface you want to run the server on
 
 When you have these things available, install bifrost:
 
@@ -89,11 +98,54 @@ At this point, the server should start: (log timestamps omitted for clarity)
 ...
 ```
 
-The log output shows Bifrost talking with zigbee2mqtt, and finding some lights to control (office_{1,2,3}).
+The log output shows Bifrost talking with zigbee2mqtt, and finding some lights to control (office\_{1,2,3}).
 
 At this point, you're running a Bifrost bridge.
 
 The Philips Hue app should be able to find it on your network!
+
+### Docker
+
+> [!WARNING]
+> Docker support just recently got [merged](https://github.com/chrivers/bifrost/pull/2) to this project. It is not optimal yet and there are no prebuilt images (yet). If you encounter any bugs or have suggestions, feel free to leave your feedback [here](#problems-questions-feedback).
+
+To install Bifrost with Docker, you will need the following:
+
+1.  At least one zigbee2mqtt server to connect to
+2.  The MAC address of the network interface you want to run the server on
+3.  A running [Docker](https://docs.docker.com/engine/install/) instance with [Docker-Compose](https://docs.docker.com/compose/install/) installed
+4.  Have `git` installed to clone this repository
+
+When you have these things available, you can install Bifrost by running these commands:
+
+```
+git clone https://github.com/chrivers/bifrost
+cd bifrost
+```
+
+Then rename or copy our `config.example.yaml`:
+
+```
+cp config.example.yaml config.yaml
+```
+
+And edit it with your favorite editor to your liking (see [configuration reference](doc/config-reference.md)).
+
+Also edit the mounts in the `docker-compose.yaml` to the paths you put your config.yaml (can also be relative, e.g., `./config.yaml`) and where you want to put the certificates, Bifrost creates.
+
+Now you are ready to run the app with:
+
+```
+docker compose up -d
+```
+
+This will build and then start the app on your Docker instance.
+
+To view the logs, use a tool like [Portainer](https://www.portainer.io/) or run the following command:
+
+```
+docker logs bifrost
+```
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ There are currently two ways you can install Bifrost.
 1.  [Install manualy](#manual) from source (for now, this is the preferred method)
 2.  [Install it via Docker](#docker) (still WIP, some aspects may not be optimal for now)
 
-When you have these things available, you can download
-
 ### Manual
 
 To install Bifrost from source, you will need the following:
@@ -108,13 +106,15 @@ The Philips Hue app should be able to find it on your network!
 
 > [!WARNING]
 > Docker support was [merged recently](https://github.com/chrivers/bifrost/pull/2).
-> If you encounter any bugs, or have suggestions, feel free to leave your feedback [here](#problems-questions-feedback).
+> If you encounter any bugs, or have suggestions, feel free to leave your feedback
+> [here](#problems-questions-feedback).
 
 To install Bifrost with Docker, you will need the following:
 
 1.  At least one zigbee2mqtt server to connect to
 2.  The MAC address of the network interface you want to run the server on
-3.  A running [Docker](https://docs.docker.com/engine/install/) instance with [Docker-Compose](https://docs.docker.com/compose/install/) installed
+3.  A running [Docker](https://docs.docker.com/engine/install/) instance
+    with [Docker-Compose](https://docs.docker.com/compose/install/) installed
 4.  Have `git` installed to clone this repository
 
 When you have these things available, you can install Bifrost by running these commands:
@@ -130,9 +130,12 @@ Then rename or copy our `config.example.yaml`:
 cp config.example.yaml config.yaml
 ```
 
-And edit it with your favorite editor to your liking (see [configuration reference](doc/config-reference.md)).
+And edit it with your favorite editor to your liking (see
+[configuration reference](doc/config-reference.md)).
 
-Also edit the mounts in the `docker-compose.yaml` to the paths you put your config.yaml (can also be relative, e.g., `./config.yaml`) and where you want to put the certificates, Bifrost creates.
+If you want to put your configuration file or the certificates Bifrost creates somewhere
+else, you also need to adjust the mount paths in the `docker-compose.yaml`. Otherwise,
+just leave the default values.
 
 Now you are ready to run the app with:
 
@@ -142,7 +145,8 @@ docker compose up -d
 
 This will build and then start the app on your Docker instance.
 
-To view the logs, use a tool like [Portainer](https://www.portainer.io/) or run the following command:
+To view the logs, use a tool like [Portainer](https://www.portainer.io/) or
+run the following command:
 
 ```
 docker logs bifrost

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,5 +1,5 @@
 bifrost:
-  # Optional but needed if using the Docker install method
+  # Override the default path to the one used in the docker image
   cert_file: "certs/cert.pem"
 
 bridge:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,4 +1,5 @@
 bifrost:
+  # Optional but needed if using the Docker install method
   cert_file: "certs/cert.pem"
 
 bridge:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,12 @@
 services:
   bifrost:
     build: .
+    container_name: bifrost
+    restart: unless-stopped
+    network_mode: host
     volumes:
+      # If you followed the guide on our readme, you could also use relative paths:
+      # - ./config.yaml:/app/config.yaml
+      # - ./certs:/app/certs
       - /path/to/app-data/config.yaml:/app/config.yaml
       - /path/to/app-data/certs:/app/certs
-    network_mode: host

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,8 +5,6 @@ services:
     restart: unless-stopped
     network_mode: host
     volumes:
-      # If you followed the guide on our readme, you could also use relative paths:
-      # - ./config.yaml:/app/config.yaml
-      # - ./certs:/app/certs
-      - /path/to/app-data/config.yaml:/app/config.yaml
-      - /path/to/app-data/certs:/app/certs
+      # If you followed the guide on our readme, these paths work out of the box
+      - ./config.yaml:/app/config.yaml
+      - ./certs:/app/certs


### PR DESCRIPTION
Hey @chrivers, me again. Just got to writing some instructions for the Docker installation.

I tried to be as clear and simple as possible. I also tried to align the style to the rest of the `readme`, hopefully that worked. I also quickly ran it through a spellcheck, but if you find anything wrong, feel free to edit it.

Quick question: I saw there is a package now that we could use as an image. I haven't tried it yet, is it ready for me to add it to the `readme` and `docker-compose`? For now, I wrote it with only having the `Dockerfile` option.

If you encounter any problems, feel free to ask and make adjustments as you like.