### PR TITLE
Add support for group_filter option on z2m server blocks

### DIFF
--- a/doc/config-reference.md
+++ b/doc/config-reference.md
@@ -57,6 +57,16 @@ z2m:
     url: ws://10.00.0.100:8080
   other-server:
     url: ws://10.10.0.102:8080
+
+    # Group prefix [optional!]
+    #
+    # If you specify this parameter, *only* groups with this prefix
+    # will be visible from this z2m server. The prefix will be removed.
+    #
+    # So with a group_prefix of "bifrost_", the group "bifrost_kitchen"
+    # will be available as "kitchen", but the group "living_room" will
+    # be hidden instead.
+    group_prefix: bifrost_
   ...
 
 # Rooms section [optional!]

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ pub struct Z2mConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Z2mServer {
     pub url: String,
+    pub group_prefix: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ async fn build_tasks(appstate: AppState) -> ApiResult<JoinSet<ApiResult<()>>> {
     for (name, server) in &appstate.config().z2m.servers {
         let client = z2m::Client::new(
             name.clone(),
-            server.url.clone(),
+            server.clone(),
             appstate.config(),
             appstate.res.clone(),
         )?;


### PR DESCRIPTION
Bifrost presents z2m groups as Rooms, but users might not want to present every single group in bifrost.

To support this, add "group_prefix" option to z2m server blocks, like so:

```yaml
...
z2m:
  myserver:
    url: ws://10.10.0.102:8080
    # Group prefix [optional!]
    #
    # If you specify this parameter, *only* groups with this prefix
    # will be visible from this z2m server. The prefix will be removed.
    #
    # So with a group_filter of "bifrost_", the group "bifrost_kitchen"
    # will be available as "kitchen", but the group "living_room" will
    # be hidden instead.
    group_filter: bifrost_
```