### PR TITLE
Optional hiding

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,7 @@ pub struct Z2mServer {
 pub struct RoomConfig {
     pub name: Option<String>,
     pub icon: Option<RoomArchetype>,
+    pub hidden: Option<bool>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/hue/api/room.rs
+++ b/src/hue/api/room.rs
@@ -73,11 +73,11 @@ pub enum RoomArchetype {
 
 impl RoomMetadata {
     #[must_use]
-    pub fn new(archetype: RoomArchetype, name: &str) -> Self {
+    pub fn new(archetype: RoomArchetype, name: &str, hidden: bool) -> Self {
         Self {
             archetype,
             name: name.to_string(),
-            hidden: false
+            hidden,
         }
     }
 }

--- a/src/hue/api/room.rs
+++ b/src/hue/api/room.rs
@@ -6,6 +6,7 @@ use crate::hue::api::{RType, ResourceLink};
 pub struct RoomMetadata {
     pub name: String,
     pub archetype: RoomArchetype,
+    pub hidden: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -76,6 +77,7 @@ impl RoomMetadata {
         Self {
             archetype,
             name: name.to_string(),
+            hidden: false
         }
     }
 }

--- a/src/z2m/mod.rs
+++ b/src/z2m/mod.rs
@@ -271,25 +271,36 @@ impl Client {
             if let Some(icon) = &room_conf.icon {
                 metadata.archetype = *icon;
             }
+            if let Some(hidden) = &room_conf.hidden {
+                metadata.hidden = *hidden;
+            }
         };
 
-        let room = Room {
-            children,
-            metadata,
-            services: vec![link_glight],
-        };
+        if !metadata.hidden {
+            let room = Room {
+                children,
+                metadata,
+                services: vec![link_glight],
+            };
+    
+            self.map.insert(topic.clone(), link_glight.rid);
+            self.rmap.insert(link_glight.rid, topic.clone());
+            self.rmap.insert(link_room.rid, topic.clone());
+    
+            res.add(&link_room, Resource::Room(room))?;
+    
+            let glight = GroupedLight::new(link_room);
+    
+            res.add(&link_glight, Resource::GroupedLight(glight))?;
+        } else {
+            log::debug!(
+                "[{}] {link_room:?} ({}) is hidden; passing on link!",
+                self.name,
+                room_name
+            );
+        }
 
-        self.map.insert(topic.clone(), link_glight.rid);
-        self.rmap.insert(link_glight.rid, topic.clone());
-        self.rmap.insert(link_room.rid, topic.clone());
-
-        res.add(&link_room, Resource::Room(room))?;
-
-        let glight = GroupedLight::new(link_room);
-
-        res.add(&link_glight, Resource::GroupedLight(glight))?;
         drop(res);
-
         Ok(())
     }
 


### PR DESCRIPTION
This will affect, but not close, #16. In particular, it looks like the rooms keys in config.yaml get all parsed as lower case, so this will work for groups that are lower case with no spaces. We should evaluate that further. Config is the same as the proposal:

```
rooms:
  desk_light_isolation:
    name: Desk Light Isolation Group
    hidden: true
```