### PR TITLE
Chrivers/issue 24

### DIFF
--- a/src/z2m/api.rs
+++ b/src/z2m/api.rs
@@ -344,7 +344,6 @@ impl Device {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Definition {
     pub description: String,
     pub exposes: Vec<Expose>,

--- a/src/z2m/api.rs
+++ b/src/z2m/api.rs
@@ -15,7 +15,6 @@ pub struct RawMessage {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
 #[serde(tag = "topic", content = "payload")]
 pub enum Message {
     #[serde(rename = "bridge/info")]
@@ -357,7 +356,6 @@ pub struct Definition {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
-#[serde(deny_unknown_fields)]
 pub enum Expose {
     Binary(ExposeBinary),
     Composite(ExposeComposite),

--- a/src/z2m/api.rs
+++ b/src/z2m/api.rs
@@ -64,13 +64,6 @@ where
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct Other {
-    pub topic: String,
-    pub payload: Value,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum BridgeOnlineState {
     Online,

--- a/src/z2m/mod.rs
+++ b/src/z2m/mod.rs
@@ -31,7 +31,7 @@ use crate::error::{ApiError, ApiResult};
 use crate::hue::scene_icons;
 use crate::model::state::AuxData;
 use crate::resource::Resources;
-use crate::z2m::api::{ExposeLight, Message, Other, RawMessage};
+use crate::z2m::api::{ExposeLight, Message, RawMessage};
 use crate::z2m::request::{ClientRequest, Z2mRequest};
 use crate::z2m::update::DeviceUpdate;
 
@@ -588,7 +588,7 @@ impl Client {
             "[{}] Topic [{topic}] known as {uuid} on this z2m connection, sending event..",
             self.name
         );
-        let api_req = Other {
+        let api_req = RawMessage {
             payload: serde_json::to_value(payload)?,
             topic: format!("{topic}/set"),
         };


### PR DESCRIPTION
 * Remove serde(deny_unknown_fields) in z2m::api::Definition (fixes #24)
 * Remove serde(deny_unknown_fields) on enums in z2m api
 * Merge identical struct z2m::api::{Other,RawMessage} into RawMessage.