### PR TITLE
Chrivers/device update

### DIFF
--- a/src/hue/api/device.rs
+++ b/src/hue/api/device.rs
@@ -1,3 +1,5 @@
+use std::ops::{AddAssign, Sub};
+
 use serde::{Deserialize, Serialize};
 
 use crate::hue::api::{Metadata, MetadataUpdate, RType, ResourceLink, Stub};
@@ -106,6 +108,45 @@ impl DeviceUpdate {
                 name: Some(metadata.name),
             }),
         }
+    }
+}
+
+impl AddAssign<DeviceUpdate> for Device {
+    fn add_assign(&mut self, upd: DeviceUpdate) {
+        if let Some(md) = upd.metadata {
+            if let Some(name) = md.name {
+                self.metadata.name = name;
+            }
+            if let Some(archetype) = md.archetype {
+                self.metadata.archetype = archetype;
+            }
+        }
+    }
+}
+
+#[allow(clippy::if_not_else)]
+impl Sub<&Device> for &Device {
+    type Output = DeviceUpdate;
+
+    fn sub(self, rhs: &Device) -> Self::Output {
+        let mut upd = Self::Output::default();
+
+        if self.metadata != rhs.metadata {
+            upd.metadata = Some(MetadataUpdate {
+                name: if self.metadata.name != rhs.metadata.name {
+                    Some(rhs.metadata.name.clone())
+                } else {
+                    None
+                },
+                archetype: if self.metadata.archetype != rhs.metadata.archetype {
+                    Some(rhs.metadata.archetype.clone())
+                } else {
+                    None
+                },
+            });
+        }
+
+        upd
     }
 }
 

--- a/src/hue/api/device.rs
+++ b/src/hue/api/device.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::hue::api::{Metadata, RType, ResourceLink, Stub};
+use crate::hue::api::{Metadata, MetadataUpdate, RType, ResourceLink, Stub};
 use crate::hue::version::SwVersion;
 use crate::hue::HUE_BRIDGE_V2_MODEL_ID;
 use crate::z2m;
@@ -14,6 +14,12 @@ pub struct Device {
     pub usertest: Option<UserTest>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub identify: Option<Stub>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct DeviceUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<MetadataUpdate>,
 }
 
 impl Device {
@@ -82,6 +88,23 @@ impl DeviceProductData {
             certified,
             software_version,
             hardware_platform_type: None,
+        }
+    }
+}
+
+impl DeviceUpdate {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn with_metadata(self, metadata: Metadata) -> Self {
+        Self {
+            metadata: Some(MetadataUpdate {
+                archetype: Some(metadata.archetype),
+                name: Some(metadata.name),
+            }),
         }
     }
 }

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -4,7 +4,7 @@ use std::ops::{AddAssign, Sub};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::hue::api::{DeviceArchetype, Identify, Metadata, ResourceLink, Stub};
+use crate::hue::api::{DeviceArchetype, Identify, Metadata, MetadataUpdate, ResourceLink, Stub};
 use crate::model::types::XY;
 use crate::z2m::api::Expose;
 
@@ -45,7 +45,7 @@ pub struct Light {
     pub signaling: Option<LightSignaling>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum LightFunction {
     Functional,
@@ -53,7 +53,7 @@ pub enum LightFunction {
     Mixed,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct LightMetadata {
     pub name: String,
     pub archetype: DeviceArchetype,
@@ -136,7 +136,16 @@ impl Light {
 
 impl AddAssign<LightUpdate> for Light {
     fn add_assign(&mut self, upd: LightUpdate) {
-        if let Some(state) = &upd.on {
+        if let Some(md) = upd.metadata {
+            if let Some(name) = md.name {
+                self.metadata.name = name;
+            }
+            if let Some(archetype) = md.archetype {
+                self.metadata.archetype = archetype;
+            }
+        }
+
+        if let Some(state) = upd.on {
             self.on.on = state.on;
         }
 
@@ -161,16 +170,27 @@ impl AddAssign<LightUpdate> for Light {
     }
 }
 
+#[allow(clippy::if_not_else)]
 impl Sub<&Light> for &Light {
     type Output = LightUpdate;
 
     fn sub(self, rhs: &Light) -> Self::Output {
-        let mut upd = Self::Output {
-            on: None,
-            dimming: None,
-            color: None,
-            color_temperature: None,
-        };
+        let mut upd = Self::Output::default();
+
+        if self.metadata != rhs.metadata {
+            upd.metadata = Some(MetadataUpdate {
+                name: if self.metadata.name != rhs.metadata.name {
+                    Some(rhs.metadata.name.clone())
+                } else {
+                    None
+                },
+                archetype: if self.metadata.archetype != rhs.metadata.archetype {
+                    Some(rhs.metadata.archetype.clone())
+                } else {
+                    None
+                },
+            });
+        }
 
         if self.on != rhs.on {
             upd.on = Some(rhs.on);
@@ -346,6 +366,8 @@ pub struct LightTimedEffects {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct LightUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<MetadataUpdate>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub on: Option<On>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/hue/api/mod.rs
+++ b/src/hue/api/mod.rs
@@ -15,7 +15,7 @@ pub use light::{
     DimmingUpdate, GamutType, Light, LightColor, LightMetadata, LightUpdate, MirekSchema, On,
 };
 pub use resource::{RType, ResourceLink, ResourceRecord};
-pub use room::{Room, RoomArchetype, RoomMetadata};
+pub use room::{Room, RoomArchetype, RoomMetadata, RoomMetadataUpdate, RoomUpdate};
 pub use scene::{
     Scene, SceneAction, SceneActionElement, SceneMetadata, SceneRecall, SceneStatus,
     SceneStatusUpdate, SceneUpdate,

--- a/src/hue/api/mod.rs
+++ b/src/hue/api/mod.rs
@@ -7,7 +7,8 @@ mod scene;
 mod stubs;
 mod update;
 
-pub use device::{Device, DeviceArchetype, DeviceProductData, Identify};
+pub use device::{Device, DeviceArchetype, DeviceProductData, DeviceUpdate, Identify};
+
 pub use grouped_light::{GroupedLight, GroupedLightUpdate};
 pub use light::{
     ColorGamut, ColorTemperature, ColorTemperatureUpdate, ColorUpdate, Delta, Dimming,
@@ -24,8 +25,9 @@ pub use stubs::{
     ButtonData, ButtonMetadata, ButtonReport, DevicePower, DeviceSoftwareUpdate, DollarRef,
     Entertainment, EntertainmentConfiguration, EntertainmentSegment, EntertainmentSegments,
     GeofenceClient, Geolocation, GroupedLightLevel, GroupedMotion, Homekit, LightLevel, Matter,
-    Metadata, Motion, PrivateGroup, PublicImage, RelativeRotary, SmartScene, Taurus, Temperature,
-    TimeZone, ZigbeeConnectivity, ZigbeeConnectivityStatus, ZigbeeDeviceDiscovery, Zone,
+    Metadata, MetadataUpdate, Motion, PrivateGroup, PublicImage, RelativeRotary, SmartScene,
+    Taurus, Temperature, TimeZone, ZigbeeConnectivity, ZigbeeConnectivityStatus,
+    ZigbeeDeviceDiscovery, Zone,
 };
 pub use update::{Update, UpdateRecord};
 

--- a/src/hue/api/room.rs
+++ b/src/hue/api/room.rs
@@ -1,19 +1,33 @@
+use std::ops::{AddAssign, Sub};
+
 use serde::{Deserialize, Serialize};
 
 use crate::hue::api::{RType, ResourceLink};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct RoomMetadata {
     pub name: String,
     pub archetype: RoomArchetype,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct RoomMetadataUpdate {
+    pub name: Option<String>,
+    pub archetype: Option<RoomArchetype>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Room {
     pub children: Vec<ResourceLink>,
     pub metadata: RoomMetadata,
     #[serde(default)]
     pub services: Vec<ResourceLink>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct RoomUpdate {
+    pub children: Option<Vec<ResourceLink>>,
+    pub metadata: Option<RoomMetadataUpdate>,
 }
 
 impl Room {
@@ -25,7 +39,25 @@ impl Room {
     }
 }
 
-#[derive(Copy, Debug, Serialize, Deserialize, Clone)]
+impl RoomUpdate {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn with_metadata(self, metadata: RoomMetadata) -> Self {
+        Self {
+            metadata: Some(RoomMetadataUpdate {
+                name: Some(metadata.name),
+                archetype: Some(metadata.archetype),
+            }),
+            ..self
+        }
+    }
+}
+
+#[derive(Copy, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RoomArchetype {
     LivingRoom,
@@ -77,5 +109,56 @@ impl RoomMetadata {
             archetype,
             name: name.to_string(),
         }
+    }
+}
+
+impl AddAssign<RoomMetadataUpdate> for RoomMetadata {
+    fn add_assign(&mut self, upd: RoomMetadataUpdate) {
+        if let Some(name) = upd.name {
+            self.name = name;
+        }
+        if let Some(archetype) = upd.archetype {
+            self.archetype = archetype;
+        }
+    }
+}
+
+#[allow(clippy::if_not_else)]
+impl Sub<&RoomMetadata> for &RoomMetadata {
+    type Output = RoomMetadataUpdate;
+
+    fn sub(self, rhs: &RoomMetadata) -> Self::Output {
+        let mut upd = Self::Output::default();
+
+        if self != rhs {
+            if self.name != rhs.name {
+                upd.name = Some(rhs.name.clone());
+            }
+            if self.archetype != rhs.archetype {
+                upd.archetype = Some(rhs.archetype);
+            }
+        }
+
+        upd
+    }
+}
+
+#[allow(clippy::if_not_else)]
+impl Sub<&Room> for &Room {
+    type Output = RoomUpdate;
+
+    fn sub(self, rhs: &Room) -> Self::Output {
+        let mut upd = Self::Output::default();
+
+        if self != rhs {
+            if self.children != rhs.children {
+                upd.children = Some(rhs.children.clone());
+            }
+            if self.metadata != rhs.metadata {
+                upd.metadata = Some(&self.metadata - &rhs.metadata);
+            }
+        }
+
+        upd
     }
 }

--- a/src/hue/api/scene.rs
+++ b/src/hue/api/scene.rs
@@ -1,3 +1,5 @@
+use std::ops::{AddAssign, Sub};
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -71,7 +73,7 @@ pub struct SceneActionElement {
     pub target: ResourceLink,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct SceneMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub appdata: Option<String>,
@@ -80,11 +82,19 @@ pub struct SceneMetadata {
     pub name: String,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+pub struct SceneMetadataUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub appdata: Option<String>,
+    pub image: Option<ResourceLink>,
+    pub name: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct SceneUpdate {
     pub actions: Option<Vec<SceneActionElement>>,
     pub recall: Option<SceneRecall>,
-    pub metadata: Option<SceneMetadata>,
+    pub metadata: Option<SceneMetadataUpdate>,
     pub palette: Option<Value>,
     pub speed: Option<f64>,
     pub auto_dynamic: Option<bool>,
@@ -115,6 +125,43 @@ impl SceneUpdate {
             }),
             ..self
         }
+    }
+}
+
+
+impl AddAssign<SceneMetadataUpdate> for SceneMetadata {
+    fn add_assign(&mut self, upd: SceneMetadataUpdate) {
+        if let Some(appdata) = upd.appdata {
+            self.appdata = Some(appdata);
+        }
+        if let Some(image) = upd.image {
+            self.image = Some(image);
+        }
+        if let Some(name) = upd.name {
+            self.name = name;
+        }
+    }
+}
+
+impl Sub<&SceneMetadata> for &SceneMetadata {
+    type Output = SceneMetadataUpdate;
+
+    fn sub(self, rhs: &SceneMetadata) -> Self::Output {
+        let mut upd = Self::Output::default();
+
+        if self != rhs {
+            if self.appdata != rhs.appdata {
+                upd.appdata = rhs.appdata.clone();
+            }
+            if self.image != rhs.image {
+                upd.image = rhs.image.clone();
+            }
+            if self.name != rhs.name {
+                upd.name = Some(rhs.name.clone());
+            }
+        }
+
+        upd
     }
 }
 

--- a/src/hue/api/scene.rs
+++ b/src/hue/api/scene.rs
@@ -151,10 +151,10 @@ impl Sub<&SceneMetadata> for &SceneMetadata {
 
         if self != rhs {
             if self.appdata != rhs.appdata {
-                upd.appdata = rhs.appdata.clone();
+                upd.appdata.clone_from(&rhs.appdata);
             }
             if self.image != rhs.image {
-                upd.image = rhs.image.clone();
+                upd.image.clone_from(&rhs.image);
             }
             if self.name != rhs.name {
                 upd.name = Some(rhs.name.clone());

--- a/src/hue/api/stubs.rs
+++ b/src/hue/api/stubs.rs
@@ -342,7 +342,7 @@ impl TimeZone {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Metadata {
     pub name: String,
     pub archetype: DeviceArchetype,
@@ -356,4 +356,10 @@ impl Metadata {
             name: name.to_string(),
         }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct MetadataUpdate {
+    pub name: Option<String>,
+    pub archetype: Option<DeviceArchetype>,
 }

--- a/src/hue/api/update.rs
+++ b/src/hue/api/update.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::hue::api::{GroupedLightUpdate, LightUpdate, RType, SceneUpdate};
+use crate::hue::api::{DeviceUpdate, GroupedLightUpdate, LightUpdate, RType, SceneUpdate};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -10,7 +10,7 @@ pub enum Update {
     /* BehaviorInstance(BehaviorInstanceUpdate), */
     /* Bridge(BridgeUpdate), */
     /* BridgeHome(BridgeHomeUpdate), */
-    /* Device(DeviceUpdate), */
+    Device(DeviceUpdate),
     /* Entertainment(EntertainmentUpdate), */
     /* GeofenceClient(GeofenceClientUpdate), */
     /* Geolocation(GeolocationUpdate), */
@@ -32,6 +32,7 @@ impl Update {
     pub const fn rtype(&self) -> RType {
         match self {
             Self::GroupedLight(_) => RType::GroupedLight,
+            Self::Device(_) => RType::Device,
             Self::Light(_) => RType::Light,
             Self::Scene(_) => RType::Scene,
         }
@@ -41,6 +42,7 @@ impl Update {
     pub fn id_v1_scope(&self, id: u32, uuid: &Uuid) -> Option<String> {
         match self {
             Self::GroupedLight(_) => Some(format!("/groups/{id}")),
+            Self::Device(_) => Some(format!("/device/{id}")),
             Self::Light(_) => Some(format!("/lights/{id}")),
             Self::Scene(_) => Some(format!("/scenes/{uuid}")),
         }

--- a/src/hue/api/update.rs
+++ b/src/hue/api/update.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::hue::api::{DeviceUpdate, GroupedLightUpdate, LightUpdate, RType, SceneUpdate};
+use crate::hue::api::{
+    DeviceUpdate, GroupedLightUpdate, LightUpdate, RType, RoomUpdate, SceneUpdate,
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -19,7 +21,7 @@ pub enum Update {
     Light(LightUpdate),
     /* Matter(MatterUpdate), */
     /* PublicImage(PublicImageUpdate), */
-    /* Room(RoomUpdate), */
+    Room(RoomUpdate),
     Scene(SceneUpdate),
     /* SmartScene(SmartSceneUpdate), */
     /* ZigbeeConnectivity(ZigbeeConnectivityUpdate), */
@@ -34,6 +36,7 @@ impl Update {
             Self::GroupedLight(_) => RType::GroupedLight,
             Self::Device(_) => RType::Device,
             Self::Light(_) => RType::Light,
+            Self::Room(_) => RType::Room,
             Self::Scene(_) => RType::Scene,
         }
     }
@@ -41,7 +44,7 @@ impl Update {
     #[must_use]
     pub fn id_v1_scope(&self, id: u32, uuid: &Uuid) -> Option<String> {
         match self {
-            Self::GroupedLight(_) => Some(format!("/groups/{id}")),
+            Self::Room(_) | Self::GroupedLight(_) => Some(format!("/groups/{id}")),
             Self::Device(_) => Some(format!("/device/{id}")),
             Self::Light(_) => Some(format!("/lights/{id}")),
             Self::Scene(_) => Some(format!("/scenes/{uuid}")),

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -10,8 +10,8 @@ use uuid::Uuid;
 use crate::error::{ApiError, ApiResult};
 use crate::hue::api::{
     Bridge, BridgeHome, Device, DeviceArchetype, DeviceProductData, DeviceUpdate, Metadata, RType,
-    Resource, ResourceLink, ResourceRecord, TimeZone, ZigbeeConnectivity, ZigbeeConnectivityStatus,
-    ZigbeeDeviceDiscovery,
+    Resource, ResourceLink, ResourceRecord, RoomUpdate, TimeZone, ZigbeeConnectivity,
+    ZigbeeConnectivityStatus, ZigbeeDeviceDiscovery,
 };
 use crate::hue::api::{GroupedLightUpdate, LightUpdate, SceneUpdate, Update};
 use crate::hue::event::EventBlock;
@@ -104,7 +104,11 @@ impl Resources {
 
                 Ok(Some(Update::Device(upd)))
             }
-            Resource::Room(_) => Ok(None),
+            Resource::Room(room) => {
+                let upd = RoomUpdate::new().with_metadata(room.metadata.clone());
+
+                Ok(Some(Update::Room(upd)))
+            }
             obj => Err(ApiError::UpdateUnsupported(obj.rtype())),
         }
     }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -9,8 +9,8 @@ use uuid::Uuid;
 
 use crate::error::{ApiError, ApiResult};
 use crate::hue::api::{
-    Bridge, BridgeHome, Device, DeviceArchetype, DeviceProductData, Metadata, RType, Resource,
-    ResourceLink, ResourceRecord, TimeZone, ZigbeeConnectivity, ZigbeeConnectivityStatus,
+    Bridge, BridgeHome, Device, DeviceArchetype, DeviceProductData, DeviceUpdate, Metadata, RType,
+    Resource, ResourceLink, ResourceRecord, TimeZone, ZigbeeConnectivity, ZigbeeConnectivityStatus,
     ZigbeeDeviceDiscovery,
 };
 use crate::hue::api::{GroupedLightUpdate, LightUpdate, SceneUpdate, Update};
@@ -98,6 +98,11 @@ impl Resources {
                     .with_recall_action(scene.status);
 
                 Ok(Some(Update::Scene(upd)))
+            }
+            Resource::Device(device) => {
+                let upd = DeviceUpdate::new().with_metadata(device.metadata.clone());
+
+                Ok(Some(Update::Device(upd)))
             }
             Resource::Room(_) => Ok(None),
             obj => Err(ApiError::UpdateUnsupported(obj.rtype())),

--- a/src/routes/clip/device.rs
+++ b/src/routes/clip/device.rs
@@ -1,0 +1,41 @@
+use axum::{
+    extract::{Path, State},
+    routing::put,
+    Json, Router,
+};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::hue::api::{Device, DeviceUpdate, RType, V2Reply};
+use crate::routes::clip::ApiV2Result;
+use crate::server::appstate::AppState;
+
+async fn put_device(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(put): Json<Value>,
+) -> ApiV2Result {
+    log::info!("PUT device/{id}");
+    log::debug!("json data\n{}", serde_json::to_string_pretty(&put)?);
+
+    let rlink = RType::Device.link_to(id);
+
+    let upd: DeviceUpdate = serde_json::from_value(put)?;
+
+    state.res.lock().await.update::<Device>(&id, |obj| {
+        if let Some(md) = upd.metadata {
+            if let Some(name) = md.name {
+                obj.metadata.name = name;
+            }
+            if let Some(archetype) = md.archetype {
+                obj.metadata.archetype = archetype;
+            }
+        }
+    })?;
+
+    V2Reply::ok(rlink)
+}
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/:id", put(put_device))
+}

--- a/src/routes/clip/device.rs
+++ b/src/routes/clip/device.rs
@@ -22,16 +22,11 @@ async fn put_device(
 
     let upd: DeviceUpdate = serde_json::from_value(put)?;
 
-    state.res.lock().await.update::<Device>(&id, |obj| {
-        if let Some(md) = upd.metadata {
-            if let Some(name) = md.name {
-                obj.metadata.name = name;
-            }
-            if let Some(archetype) = md.archetype {
-                obj.metadata.archetype = archetype;
-            }
-        }
-    })?;
+    state
+        .res
+        .lock()
+        .await
+        .update::<Device>(&id, |obj| *obj += upd)?;
 
     V2Reply::ok(rlink)
 }

--- a/src/routes/clip/mod.rs
+++ b/src/routes/clip/mod.rs
@@ -1,3 +1,4 @@
+pub mod device;
 pub mod generic;
 pub mod grouped_light;
 pub mod light;
@@ -38,6 +39,7 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .nest("/scene", scene::router())
         .nest("/light", light::router())
+        .nest("/device", device::router())
         .nest("/grouped_light", grouped_light::router())
         .nest("/", generic::router())
 }

--- a/src/routes/clip/scene.rs
+++ b/src/routes/clip/scene.rs
@@ -67,7 +67,7 @@ async fn put_scene(
     let upd: SceneUpdate = serde_json::from_value(put)?;
 
     if let Some(md) = upd.metadata {
-        lock.update(&id, |scn: &mut Scene| {
+        lock.update::<Scene>(&id, |scn| {
             if md.appdata.is_some() {
                 scn.metadata.appdata = md.appdata;
             }
@@ -84,7 +84,7 @@ async fn put_scene(
         if recall.action == Some(SceneStatusUpdate::Active) {
             let scenes = lock.get_scenes_for_room(&scene.group.rid);
             for rid in scenes {
-                lock.update(&rid, |scn: &mut Scene| {
+                lock.update::<Scene>(&rid, |scn| {
                     if rid == id {
                         scn.status = Some(SceneStatus::Static);
                     } else {

--- a/src/routes/clip/scene.rs
+++ b/src/routes/clip/scene.rs
@@ -77,11 +77,11 @@ async fn put_scene(
             let scenes = lock.get_scenes_for_room(&scene.group.rid);
             for rid in scenes {
                 lock.update::<Scene>(&rid, |scn| {
-                    if rid == id {
-                        scn.status = Some(SceneStatus::Static);
+                    scn.status = if rid == id {
+                        Some(SceneStatus::Static)
                     } else {
-                        scn.status = Some(SceneStatus::Inactive);
-                    }
+                        Some(SceneStatus::Inactive)
+                    };
                 })?;
             }
 

--- a/src/routes/clip/scene.rs
+++ b/src/routes/clip/scene.rs
@@ -67,15 +67,7 @@ async fn put_scene(
     let upd: SceneUpdate = serde_json::from_value(put)?;
 
     if let Some(md) = upd.metadata {
-        lock.update::<Scene>(&id, |scn| {
-            if md.appdata.is_some() {
-                scn.metadata.appdata = md.appdata;
-            }
-            if md.image.is_some() {
-                scn.metadata.image = md.image;
-            }
-            scn.metadata.name = md.name;
-        })?;
+        lock.update::<Scene>(&id, |scn| scn.metadata += md)?;
     }
 
     let scene = lock.get::<Scene>(&rlink)?;

--- a/src/z2m/mod.rs
+++ b/src/z2m/mod.rs
@@ -378,9 +378,7 @@ impl Client {
                         target: RType::Light.link_to(uuid),
                     })
                     .collect();
-                res.update(uuid, |scene: &mut Scene| {
-                    scene.actions = actions;
-                })?;
+                res.update::<Scene>(uuid, |scene| scene.actions = actions)?;
             }
         }
         drop(res);


### PR DESCRIPTION
This MR implements updates (http PUT) for Device objects.

This enables updating metadata for objects, such as:

 - Setting the bridge name
 - Setting the "archetype" (icon) for lights
