### PR TITLE
Chrivers/normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "camino",
  "chrono",
  "clap",
+ "clap-stdin",
  "config",
  "der",
  "ecdsa",
@@ -443,6 +444,15 @@ checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-stdin"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "471df7896633bfc1e7d3da5b598422891e4cb8931210168ec63ea586e285803f"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ termcolor = { version = "1.4.1", optional = true }
 itertools = { version = "0.13.0", optional = true }
 reqwest = { version = "0.12.8", default-features = false, features = ["__tls", "json", "rustls-tls"] }
 url = { version = "2.5.4", features = ["serde"] }
+clap-stdin = "0.5.1"
 
 [dev-dependencies]
 json_diff_ng = { version = "0.6.0", default-features = false }

--- a/examples/normalize-hue-get.rs
+++ b/examples/normalize-hue-get.rs
@@ -1,15 +1,81 @@
 #![allow(unused_variables)]
 
-use std::io::stdin;
+use std::io::{stdin, Stdin};
 
 use bifrost::error::ApiResult;
 use bifrost::hue::api::ResourceRecord;
 
 use json_diff_ng::compare_serde_values;
-use serde_json::Value;
+use serde_json::{de::IoRead, Deserializer, StreamDeserializer, Value};
 
 fn false_positive((a, b): &(&Value, &Value)) -> bool {
     a.is_number() && b.is_number() && a.as_f64() == b.as_f64()
+}
+
+/*
+ * Handle both "raw" hue bridge dumps, and the "linedump" format that is
+ * generally easier to work with.
+ *
+ * For each element in the input, if it is an object, look for a ".data" array,
+ * and if found, iterate over that. Otherwise, assume the whole object is what
+ * we are parsing.
+ */
+fn extract(
+    stream: StreamDeserializer<IoRead<Stdin>, Value>,
+) -> impl Iterator<Item = (usize, Value)> + '_ {
+    stream
+        .flat_map(|val| {
+            val.as_ref()
+                .unwrap()
+                .as_object()
+                .and_then(|obj| obj.get("data"))
+                .map(|data| data.as_array().unwrap().to_owned())
+                .unwrap_or_else(|| vec![val.unwrap()])
+        })
+        .enumerate()
+}
+
+fn compare(before: &Value, after: &Value, msg: ResourceRecord) -> ApiResult<()> {
+    let diffs = compare_serde_values(before, after, true, &[]).unwrap();
+    let all_diffs = diffs.all_diffs();
+
+    if !all_diffs
+        .iter()
+        .any(|x| x.1.values.map(|q| !false_positive(&q)).unwrap_or(true))
+    {
+        return Ok(());
+    }
+
+    log::error!("Difference detected on {:?}", msg.obj.rtype());
+    eprintln!("--------------------------------------------------------------------------------");
+    println!("{}", serde_json::to_string(before)?);
+    eprintln!("--------------------------------------------------------------------------------");
+    println!("{}", serde_json::to_string(&msg)?);
+    eprintln!("--------------------------------------------------------------------------------");
+    for (d_type, d_path) in all_diffs {
+        if let Some(ref ab) = d_path.values {
+            if false_positive(ab) {
+                continue;
+            }
+        }
+        match d_type {
+            json_diff_ng::DiffType::LeftExtra => {
+                eprintln!(" - {d_path}");
+            }
+            json_diff_ng::DiffType::Mismatch => {
+                eprintln!(" * {d_path}");
+            }
+            json_diff_ng::DiffType::RightExtra => {
+                eprintln!(" + {d_path}");
+            }
+            json_diff_ng::DiffType::RootMismatch => {
+                eprintln!("{d_type}: {d_path}");
+            }
+        }
+    }
+    eprintln!();
+
+    Ok(())
 }
 
 #[tokio::main]
@@ -19,61 +85,22 @@ async fn main() -> ApiResult<()> {
         .parse_default_env()
         .init();
 
-    for (index, line) in stdin().lines().enumerate() {
-        let line = line?;
-        let before: Value = serde_json::from_str(&line)?;
-        let data: Result<ResourceRecord, _> = serde_json::from_str(&line);
+    let stream = Deserializer::from_reader(stdin()).into_iter::<Value>();
+
+    for (index, obj) in extract(stream) {
+        let before = obj;
+        let data: Result<ResourceRecord, _> = serde_json::from_value(before.clone());
 
         let Ok(msg) = data else {
             let err = data.unwrap_err();
-            log::error!("Parse error {err:?} (stdin line {})", index + 1);
-            eprintln!("{}", &line);
+            log::error!("Parse error {err:?} (object index {})", index);
+            eprintln!("{}", &serde_json::to_string(&before)?);
             continue;
         };
 
         let after = serde_json::to_value(&msg)?;
 
-        let diffs = compare_serde_values(&before, &after, true, &[]).unwrap();
-        if diffs
-            .all_diffs()
-            .iter()
-            .any(|x| x.1.values.map(|q| !false_positive(&q)).unwrap_or(true))
-        {
-            log::error!("Difference detected on {:?}", msg.obj.rtype());
-            println!(
-                "--------------------------------------------------------------------------------"
-            );
-            println!("{}", &line);
-            println!(
-                "--------------------------------------------------------------------------------"
-            );
-            println!("{}", serde_json::to_string(&msg)?);
-            println!(
-                "--------------------------------------------------------------------------------"
-            );
-            for (d_type, d_path) in diffs.all_diffs() {
-                if let Some(ref ab) = d_path.values {
-                    if false_positive(ab) {
-                        continue;
-                    }
-                }
-                match d_type {
-                    json_diff_ng::DiffType::LeftExtra => {
-                        eprintln!(" - {d_path}");
-                    }
-                    json_diff_ng::DiffType::Mismatch => {
-                        eprintln!(" * {d_path}");
-                    }
-                    json_diff_ng::DiffType::RightExtra => {
-                        eprintln!(" + {d_path}");
-                    }
-                    json_diff_ng::DiffType::RootMismatch => {
-                        eprintln!("{d_type}: {d_path}");
-                    }
-                }
-            }
-            eprintln!();
-        }
+        compare(&before, &after, msg)?;
     }
 
     Ok(())

--- a/examples/normalize-hue-get.rs
+++ b/examples/normalize-hue-get.rs
@@ -78,8 +78,7 @@ fn compare(before: &Value, after: &Value, msg: ResourceRecord) -> ApiResult<()> 
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> ApiResult<()> {
+fn main() -> ApiResult<()> {
     pretty_env_logger::formatted_builder()
         .filter_level(log::LevelFilter::Debug)
         .parse_default_env()

--- a/examples/normalize-hue-get.rs
+++ b/examples/normalize-hue-get.rs
@@ -124,6 +124,16 @@ struct Args {
     files: Vec<Utf8PathBuf>,
 }
 
+impl Args {
+    pub fn longest_filename(&self) -> usize {
+        self.files
+            .iter()
+            .map(|b| b.as_str().len().max(5))
+            .max()
+            .unwrap_or(5)
+    }
+}
+
 fn main() -> ApiResult<()> {
     pretty_env_logger::formatted_builder()
         .filter_level(log::LevelFilter::Debug)
@@ -131,12 +141,7 @@ fn main() -> ApiResult<()> {
         .init();
 
     let args = Args::parse();
-    let width = args
-        .files
-        .iter()
-        .map(|b| b.as_str().len().max(5))
-        .max()
-        .unwrap();
+    let width = args.longest_filename();
 
     for file in args.files {
         if file == "-" {

--- a/src/hue/api/device.rs
+++ b/src/hue/api/device.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::hue::api::{Metadata, RType, ResourceLink};
+use crate::hue::api::{Metadata, RType, ResourceLink, Stub};
 use crate::hue::version::SwVersion;
 use crate::hue::HUE_BRIDGE_V2_MODEL_ID;
 use crate::z2m;
@@ -10,8 +10,10 @@ pub struct Device {
     pub product_data: DeviceProductData,
     pub metadata: Metadata,
     pub services: Vec<ResourceLink>,
-    #[serde(default)]
-    pub identify: Identify,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usertest: Option<UserTest>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identify: Option<Stub>,
 }
 
 impl Device {
@@ -23,6 +25,12 @@ impl Device {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Identify {}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct UserTest {
+    status: String,
+    usertest: bool,
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DeviceProductData {

--- a/src/hue/api/grouped_light.rs
+++ b/src/hue/api/grouped_light.rs
@@ -14,7 +14,9 @@ pub struct GroupedLight {
     pub color_temperature: Option<Stub>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color_temperature_delta: Option<Stub>,
+    #[serde(default)]
     pub dimming_delta: Stub,
+    #[serde(default)]
     pub dynamics: Stub,
     pub on: Option<On>,
     pub owner: ResourceLink,

--- a/src/hue/api/grouped_light.rs
+++ b/src/hue/api/grouped_light.rs
@@ -8,9 +8,12 @@ use crate::model::types::XY;
 pub struct GroupedLight {
     pub alert: Value,
     pub dimming: Option<DimmingUpdate>,
-    pub color: Stub,
-    pub color_temperature: Stub,
-    pub color_temperature_delta: Stub,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<Stub>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_temperature: Option<Stub>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_temperature_delta: Option<Stub>,
     pub dimming_delta: Stub,
     pub dynamics: Stub,
     pub on: Option<On>,
@@ -24,9 +27,9 @@ impl GroupedLight {
         Self {
             alert: Value::Null,
             dimming: None,
-            color: Stub {},
-            color_temperature: Stub {},
-            color_temperature_delta: Stub {},
+            color: Some(Stub {}),
+            color_temperature: Some(Stub {}),
+            color_temperature_delta: Some(Stub {}),
             dimming_delta: Stub {},
             dynamics: Stub {},
             on: None,

--- a/src/hue/api/grouped_light.rs
+++ b/src/hue/api/grouped_light.rs
@@ -1,13 +1,18 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::hue::api::{ColorTemperatureUpdate, ColorUpdate, DimmingUpdate, On, ResourceLink};
+use crate::hue::api::{ColorTemperatureUpdate, ColorUpdate, DimmingUpdate, On, ResourceLink, Stub};
 use crate::model::types::XY;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GroupedLight {
     pub alert: Value,
     pub dimming: Option<DimmingUpdate>,
+    pub color: Stub,
+    pub color_temperature: Stub,
+    pub color_temperature_delta: Stub,
+    pub dimming_delta: Stub,
+    pub dynamics: Stub,
     pub on: Option<On>,
     pub owner: ResourceLink,
     pub signaling: Value,
@@ -19,6 +24,11 @@ impl GroupedLight {
         Self {
             alert: Value::Null,
             dimming: None,
+            color: Stub {},
+            color_temperature: Stub {},
+            color_temperature_delta: Stub {},
+            dimming_delta: Stub {},
+            dynamics: Stub {},
             on: None,
             owner: room,
             signaling: Value::Null,

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -22,7 +22,9 @@ pub struct Light {
     pub color_temperature: Option<ColorTemperature>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color_temperature_delta: Option<Stub>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dimming: Option<Dimming>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dimming_delta: Option<Stub>,
     pub dynamics: Option<LightDynamics>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -39,6 +41,7 @@ pub struct Light {
     pub on: On,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub powerup: Option<LightPowerup>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub signaling: Option<LightSignaling>,
 }
 

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -212,8 +212,68 @@ pub enum LightPowerupPreset {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LightPowerup {
     pub preset: LightPowerupPreset,
-    #[serde(flatten)]
-    pub data: Value,
+
+    pub configured: bool,
+    #[serde(default, skip_serializing_if = "LightPowerupOn::is_none")]
+    pub on: LightPowerupOn,
+    #[serde(default, skip_serializing_if = "LightPowerupDimming::is_none")]
+    pub dimming: LightPowerupDimming,
+    #[serde(default, skip_serializing_if = "LightPowerupColor::is_none")]
+    pub color: LightPowerupColor,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum LightPowerupOn {
+    #[default]
+    None,
+    Previous,
+    On {
+        on: On,
+    },
+}
+
+impl LightPowerupOn {
+    pub const fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum LightPowerupColor {
+    #[default]
+    None,
+    Previous,
+    Color {
+        color: ColorUpdate,
+    },
+    ColorTemperature {
+        color_temperature: ColorTemperatureUpdate,
+    },
+}
+
+impl LightPowerupColor {
+    pub const fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum LightPowerupDimming {
+    #[default]
+    None,
+    Previous,
+    Dimming {
+        dimming: DimmingUpdate,
+    },
+}
+
+impl LightPowerupDimming {
+    pub const fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::ops::{AddAssign, Sub};
 
 use serde::{Deserialize, Serialize};
@@ -32,7 +33,7 @@ pub struct Light {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_id: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gradient: Option<Value>,
+    pub gradient: Option<LightGradient>,
     #[serde(default)]
     pub identify: Identify,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -198,6 +199,22 @@ pub enum LightMode {
     #[default]
     Normal,
     Streaming,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialOrd, Ord, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum LightGradientMode {
+    InterpolatedPalette,
+    InterpolatedPaletteMirrored,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LightGradient {
+    mode: LightGradientMode,
+    mode_values: BTreeSet<LightGradientMode>,
+    points_capable: u32,
+    points: Vec<Value>,
+    pixel_count: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -402,6 +402,7 @@ pub enum GamutType {
     A,
     B,
     C,
+    #[serde(rename = "other")]
     Other,
 }
 

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -38,6 +38,7 @@ pub struct Light {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum LightFunction {
+    Functional,
     Decorative,
     Mixed,
 }

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -16,12 +16,15 @@ pub struct Light {
 
     #[serde(default)]
     pub alert: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<LightColor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color_temperature: Option<ColorTemperature>,
     pub color_temperature_delta: Stub,
     pub dimming: Option<Dimming>,
     pub dimming_delta: Stub,
     pub dynamics: Option<LightDynamics>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub effects: Option<LightEffects>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_id: Option<u32>,
@@ -31,6 +34,7 @@ pub struct Light {
     pub timed_effects: Option<LightTimedEffects>,
     pub mode: LightMode,
     pub on: On,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub powerup: Option<LightPowerup>,
     pub signaling: Option<LightSignaling>,
 }
@@ -488,6 +492,7 @@ impl ColorTemperature {
 #[derive(Copy, Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Dimming {
     pub brightness: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_dim_level: Option<f64>,
 }
 

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -21,6 +21,8 @@ pub struct Light {
     pub dimming_delta: Stub,
     pub dynamics: Option<LightDynamics>,
     pub effects: Option<LightEffects>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<u32>,
     #[serde(default)]
     pub identify: Identify,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -43,6 +45,7 @@ impl Light {
             dimming_delta: Stub {},
             dynamics: None,
             effects: None,
+            service_id: None,
             identify: Identify {},
             timed_effects: None,
             mode: LightMode::Normal,

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -29,6 +29,8 @@ pub struct Light {
     pub effects: Option<LightEffects>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_id: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gradient: Option<Value>,
     #[serde(default)]
     pub identify: Identify,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -95,6 +97,7 @@ impl Light {
             dynamics: None,
             effects: None,
             service_id: None,
+            gradient: None,
             identify: Identify {},
             timed_effects: None,
             mode: LightMode::Normal,

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -56,6 +56,8 @@ pub struct LightMetadata {
     pub archetype: DeviceArchetype,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function: Option<LightFunction>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fixed_mired: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -71,6 +73,7 @@ impl LightMetadata {
             archetype,
             name: name.to_string(),
             function: None,
+            fixed_mired: None,
         }
     }
 }

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -15,8 +15,7 @@ pub struct Light {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product_data: Option<LightProductData>,
 
-    #[serde(default)]
-    pub alert: Value,
+    pub alert: Option<LightAlert>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<LightColor>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -95,7 +94,7 @@ impl Light {
     #[must_use]
     pub const fn new(owner: ResourceLink, metadata: LightMetadata) -> Self {
         Self {
-            alert: Value::Null,
+            alert: None,
             color: None,
             color_temperature: None,
             color_temperature_delta: Some(Stub {}),
@@ -199,6 +198,11 @@ pub enum LightMode {
     #[default]
     Normal,
     Streaming,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LightAlert {
+    action_values: BTreeSet<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialOrd, Ord, Eq, PartialEq)]

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -229,16 +229,16 @@ pub enum LightDynamicsStatus {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LightDynamics {
     pub status: LightDynamicsStatus,
-    pub status_values: Value,
+    pub status_values: Vec<String>,
     pub speed: f64,
     pub speed_valid: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LightEffects {
-    pub status_values: Value,
-    pub status: Value,
-    pub effect_values: Value,
+    pub status_values: Vec<String>,
+    pub status: String,
+    pub effect_values: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -20,9 +20,10 @@ pub struct Light {
     pub color: Option<LightColor>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color_temperature: Option<ColorTemperature>,
-    pub color_temperature_delta: Stub,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_temperature_delta: Option<Stub>,
     pub dimming: Option<Dimming>,
-    pub dimming_delta: Stub,
+    pub dimming_delta: Option<Stub>,
     pub dynamics: Option<LightDynamics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effects: Option<LightEffects>,
@@ -88,9 +89,9 @@ impl Light {
             alert: Value::Null,
             color: None,
             color_temperature: None,
-            color_temperature_delta: Stub {},
+            color_temperature_delta: Some(Stub {}),
             dimming: None,
-            dimming_delta: Stub {},
+            dimming_delta: Some(Stub {}),
             dynamics: None,
             effects: None,
             service_id: None,

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -3,7 +3,7 @@ use std::ops::{AddAssign, Sub};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::hue::api::{Identify, Metadata, ResourceLink};
+use crate::hue::api::{DeviceArchetype, Identify, Metadata, ResourceLink, Stub};
 use crate::model::types::XY;
 use crate::z2m::api::Expose;
 
@@ -16,7 +16,9 @@ pub struct Light {
     pub alert: Value,
     pub color: Option<LightColor>,
     pub color_temperature: Option<ColorTemperature>,
+    pub color_temperature_delta: Stub,
     pub dimming: Option<Dimming>,
+    pub dimming_delta: Stub,
     pub dynamics: Option<LightDynamics>,
     pub effects: Option<LightEffects>,
     #[serde(default)]
@@ -36,7 +38,9 @@ impl Light {
             alert: Value::Null,
             color: None,
             color_temperature: None,
+            color_temperature_delta: Stub {},
             dimming: None,
+            dimming_delta: Stub {},
             dynamics: None,
             effects: None,
             identify: Identify {},

--- a/src/hue/api/light.rs
+++ b/src/hue/api/light.rs
@@ -10,7 +10,9 @@ use crate::z2m::api::Expose;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Light {
     pub owner: ResourceLink,
-    pub metadata: Metadata,
+    pub metadata: LightMetadata,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub product_data: Option<LightProductData>,
 
     #[serde(default)]
     pub alert: Value,
@@ -33,9 +35,50 @@ pub struct Light {
     pub signaling: Option<LightSignaling>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum LightFunction {
+    Decorative,
+    Mixed,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LightMetadata {
+    pub name: String,
+    pub archetype: DeviceArchetype,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<LightFunction>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LightProductData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<LightFunction>,
+}
+
+impl LightMetadata {
+    #[must_use]
+    pub fn new(archetype: DeviceArchetype, name: &str) -> Self {
+        Self {
+            archetype,
+            name: name.to_string(),
+            function: None,
+        }
+    }
+}
+
+impl From<LightMetadata> for Metadata {
+    fn from(value: LightMetadata) -> Self {
+        Self {
+            name: value.name,
+            archetype: value.archetype,
+        }
+    }
+}
+
 impl Light {
     #[must_use]
-    pub const fn new(owner: ResourceLink, metadata: Metadata) -> Self {
+    pub const fn new(owner: ResourceLink, metadata: LightMetadata) -> Self {
         Self {
             alert: Value::Null,
             color: None,
@@ -50,6 +93,7 @@ impl Light {
             timed_effects: None,
             mode: LightMode::Normal,
             on: On { on: true },
+            product_data: None,
             metadata,
             owner,
             powerup: None,

--- a/src/hue/api/mod.rs
+++ b/src/hue/api/mod.rs
@@ -24,8 +24,8 @@ pub use stubs::{
     ButtonData, ButtonMetadata, ButtonReport, DevicePower, DeviceSoftwareUpdate, DollarRef,
     Entertainment, EntertainmentConfiguration, EntertainmentSegment, EntertainmentSegments,
     GeofenceClient, Geolocation, GroupedLightLevel, GroupedMotion, Homekit, LightLevel, Matter,
-    Metadata, Motion, PublicImage, RelativeRotary, SmartScene, Taurus, Temperature, TimeZone,
-    ZigbeeConnectivity, ZigbeeConnectivityStatus, ZigbeeDeviceDiscovery, Zone,
+    Metadata, Motion, PrivateGroup, PublicImage, RelativeRotary, SmartScene, Taurus, Temperature,
+    TimeZone, ZigbeeConnectivity, ZigbeeConnectivityStatus, ZigbeeDeviceDiscovery, Zone,
 };
 pub use update::{Update, UpdateRecord};
 
@@ -64,6 +64,7 @@ pub enum Resource {
     LightLevel(LightLevel),
     Matter(Matter),
     Motion(Motion),
+    PrivateGroup(PrivateGroup),
     PublicImage(PublicImage),
     RelativeRotary(RelativeRotary),
     Room(Room),
@@ -101,6 +102,7 @@ impl Resource {
             Self::LightLevel(_) => RType::LightLevel,
             Self::Matter(_) => RType::Matter,
             Self::Motion(_) => RType::Motion,
+            Self::PrivateGroup(_) => RType::PrivateGroup,
             Self::PublicImage(_) => RType::PublicImage,
             Self::RelativeRotary(_) => RType::RelativeRotary,
             Self::Room(_) => RType::Room,
@@ -136,6 +138,7 @@ impl Resource {
             RType::LightLevel => Self::LightLevel(from_value(obj)?),
             RType::Matter => Self::Matter(from_value(obj)?),
             RType::Motion => Self::Motion(from_value(obj)?),
+            RType::PrivateGroup => Self::PrivateGroup(from_value(obj)?),
             RType::PublicImage => Self::PublicImage(from_value(obj)?),
             RType::RelativeRotary => Self::RelativeRotary(from_value(obj)?),
             RType::Room => Self::Room(from_value(obj)?),
@@ -214,6 +217,7 @@ resource_conversion_impl!(Light);
 resource_conversion_impl!(LightLevel);
 resource_conversion_impl!(Matter);
 resource_conversion_impl!(Motion);
+resource_conversion_impl!(PrivateGroup);
 resource_conversion_impl!(PublicImage);
 resource_conversion_impl!(RelativeRotary);
 resource_conversion_impl!(Room);

--- a/src/hue/api/mod.rs
+++ b/src/hue/api/mod.rs
@@ -11,7 +11,7 @@ pub use device::{Device, DeviceArchetype, DeviceProductData, Identify};
 pub use grouped_light::{GroupedLight, GroupedLightUpdate};
 pub use light::{
     ColorGamut, ColorTemperature, ColorTemperatureUpdate, ColorUpdate, Delta, Dimming,
-    DimmingUpdate, GamutType, Light, LightColor, LightUpdate, MirekSchema, On,
+    DimmingUpdate, GamutType, Light, LightColor, LightMetadata, LightUpdate, MirekSchema, On,
 };
 pub use resource::{RType, ResourceLink, ResourceRecord};
 pub use room::{Room, RoomArchetype, RoomMetadata};

--- a/src/hue/api/resource.rs
+++ b/src/hue/api/resource.rs
@@ -29,6 +29,7 @@ pub enum RType {
     LightLevel,
     Matter,
     Motion,
+    PrivateGroup,
     PublicImage,
     RelativeRotary,
     Room,

--- a/src/hue/api/scene.rs
+++ b/src/hue/api/scene.rs
@@ -60,6 +60,8 @@ pub struct SceneAction {
     pub on: Option<On>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient: Option<Value>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub effects: Value,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/hue/api/scene.rs
+++ b/src/hue/api/scene.rs
@@ -45,6 +45,7 @@ pub struct Scene {
     pub palette: Value,
     pub speed: f64,
     pub status: Option<SceneStatus>,
+    #[serde(default)]
     pub recall: SceneRecall,
 }
 
@@ -117,7 +118,7 @@ impl SceneUpdate {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct SceneRecall {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub action: Option<SceneStatusUpdate>,

--- a/src/hue/api/scene.rs
+++ b/src/hue/api/scene.rs
@@ -58,6 +58,8 @@ pub struct SceneAction {
     pub dimming: Option<DimmingUpdate>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub on: Option<On>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gradient: Option<Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/hue/api/scene.rs
+++ b/src/hue/api/scene.rs
@@ -70,6 +70,7 @@ pub struct SceneActionElement {
 pub struct SceneMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub appdata: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<ResourceLink>,
     pub name: String,
 }

--- a/src/hue/api/scene.rs
+++ b/src/hue/api/scene.rs
@@ -41,7 +41,7 @@ pub struct Scene {
     /*     dimming: [], */
     /*     effects: [] */
     /* }, */
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Value::is_null")]
     pub palette: Value,
     pub speed: f64,
     pub status: Option<SceneStatus>,

--- a/src/hue/api/stubs.rs
+++ b/src/hue/api/stubs.rs
@@ -122,7 +122,7 @@ pub struct EntertainmentConfiguration {
     pub stream_proxy: EntertainmentConfigurationStreamProxy,
     pub locations: EntertainmentConfigurationLocations,
     pub light_services: Vec<ResourceLink>,
-    pub channels: Vec<EntertainmentConfigurationChannels>
+    pub channels: Vec<EntertainmentConfigurationChannels>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -133,12 +133,12 @@ pub struct EntertainmentConfigurationMetadata {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EntertainmentConfigurationStreamProxy {
     pub mode: String,
-    pub node: ResourceLink
+    pub node: ResourceLink,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EntertainmentConfigurationLocations {
-    pub service_locations: Vec<EntertainmentConfigurationServiceLocations>
+    pub service_locations: Vec<EntertainmentConfigurationServiceLocations>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -146,27 +146,27 @@ pub struct EntertainmentConfigurationServiceLocations {
     pub equalization_factor: u32,
     pub position: EntertainmentConfigurationPosition,
     pub positions: Vec<EntertainmentConfigurationPosition>,
-    pub service: ResourceLink
+    pub service: ResourceLink,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EntertainmentConfigurationChannels {
     pub channel_id: u32,
     pub position: EntertainmentConfigurationPosition,
-    pub members: Vec<EntertainmentConfigurationStreamMembers>
+    pub members: Vec<EntertainmentConfigurationStreamMembers>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EntertainmentConfigurationPosition {
     pub x: f64,
     pub y: f64,
-    pub z: f64
+    pub z: f64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EntertainmentConfigurationStreamMembers {
     pub service: ResourceLink,
-    pub index: u32
+    pub index: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/hue/api/stubs.rs
+++ b/src/hue/api/stubs.rs
@@ -92,6 +92,8 @@ pub struct BehaviorInstance {
     pub metadata: BehaviorInstanceMetadata,
     pub script_id: Uuid,
     pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/hue/api/stubs.rs
+++ b/src/hue/api/stubs.rs
@@ -94,6 +94,8 @@ pub struct BehaviorInstance {
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub migrated_from: Option<Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/hue/api/stubs.rs
+++ b/src/hue/api/stubs.rs
@@ -114,7 +114,60 @@ pub struct Entertainment {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct EntertainmentConfiguration {}
+pub struct EntertainmentConfiguration {
+    pub name: String,
+    pub configuration_type: String,
+    pub metadata: EntertainmentConfigurationMetadata,
+    pub status: String,
+    pub stream_proxy: EntertainmentConfigurationStreamProxy,
+    pub locations: EntertainmentConfigurationLocations,
+    pub light_services: Vec<ResourceLink>,
+    pub channels: Vec<EntertainmentConfigurationChannels>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EntertainmentConfigurationMetadata {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EntertainmentConfigurationStreamProxy {
+    pub mode: String,
+    pub node: ResourceLink
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EntertainmentConfigurationLocations {
+    pub service_locations: Vec<EntertainmentConfigurationServiceLocations>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EntertainmentConfigurationServiceLocations {
+    pub equalization_factor: u32,
+    pub position: EntertainmentConfigurationPosition,
+    pub positions: Vec<EntertainmentConfigurationPosition>,
+    pub service: ResourceLink
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EntertainmentConfigurationChannels {
+    pub channel_id: u32,
+    pub position: EntertainmentConfigurationPosition,
+    pub members: Vec<EntertainmentConfigurationStreamMembers>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EntertainmentConfigurationPosition {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EntertainmentConfigurationStreamMembers {
+    pub service: ResourceLink,
+    pub index: u32
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EntertainmentSegments {

--- a/src/hue/api/stubs.rs
+++ b/src/hue/api/stubs.rs
@@ -253,6 +253,9 @@ pub struct Motion {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PrivateGroup {}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PublicImage {}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/hue/api/stubs.rs
+++ b/src/hue/api/stubs.rs
@@ -256,7 +256,10 @@ pub struct PublicImage {}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RelativeRotary {
     pub owner: ResourceLink,
-    pub rotary_report: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relative_rotary: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rotary_report: Option<Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/hue/api/stubs.rs
+++ b/src/hue/api/stubs.rs
@@ -147,7 +147,7 @@ pub struct EntertainmentConfigurationLocations {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EntertainmentConfigurationServiceLocations {
-    pub equalization_factor: u32,
+    pub equalization_factor: f64,
     pub position: EntertainmentConfigurationPosition,
     pub positions: Vec<EntertainmentConfigurationPosition>,
     pub service: ResourceLink,

--- a/src/hue/date_format.rs
+++ b/src/hue/date_format.rs
@@ -1,5 +1,6 @@
 const FORMAT: &str = "%Y-%m-%dT%H:%M:%SZ";
 const FORMAT_MS: &str = "%Y-%m-%dT%H:%M:%S%.3fZ";
+const FORMAT_LOCAL: &str = "%Y-%m-%dT%H:%M:%S";
 const UPDATE_FORMAT: &str = "%+";
 
 pub mod utc_ms {
@@ -77,7 +78,7 @@ pub mod local {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        let dt = NaiveDateTime::parse_from_str(&s, super::FORMAT).map_err(Error::custom)?;
+        let dt = NaiveDateTime::parse_from_str(&s, super::FORMAT_LOCAL).map_err(Error::custom)?;
         dt.and_local_timezone(Local)
             .single()
             .ok_or_else(|| Error::custom("Localtime conversion failed"))

--- a/src/hue/date_format.rs
+++ b/src/hue/date_format.rs
@@ -3,17 +3,23 @@ const FORMAT_MS: &str = "%Y-%m-%dT%H:%M:%S%.3fZ";
 const FORMAT_LOCAL: &str = "%Y-%m-%dT%H:%M:%S";
 const UPDATE_FORMAT: &str = "%+";
 
+macro_rules! date_serializer {
+    ($type:ty, $fmt:expr) => {
+        pub fn serialize<S>(date: &$type, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let s = format!("{}", date.format($fmt));
+            serializer.serialize_str(&s)
+        }
+    };
+}
+
 pub mod utc_ms {
     use chrono::{DateTime, NaiveDateTime, Utc};
     use serde::{self, de::Error, Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let s = format!("{}", date.format(date_format::FORMAT_MS));
-        serializer.serialize_str(&s)
-    }
+    date_serializer!(DateTime<Utc>, super::FORMAT_MS);
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
     where
@@ -43,13 +49,7 @@ pub mod utc {
     use chrono::{DateTime, NaiveDateTime, Utc};
     use serde::{self, de::Error, Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let s = format!("{}", date.format(super::FORMAT));
-        serializer.serialize_str(&s)
-    }
+    date_serializer!(DateTime<Utc>, super::FORMAT);
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
     where
@@ -65,13 +65,7 @@ pub mod local {
     use chrono::{DateTime, Local, NaiveDateTime};
     use serde::{self, de::Error, Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(date: &DateTime<Local>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let s = format!("{}", date.format(super::FORMAT));
-        serializer.serialize_str(&s)
-    }
+    date_serializer!(DateTime<Local>, super::FORMAT_LOCAL);
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Local>, D::Error>
     where

--- a/src/hue/date_format.rs
+++ b/src/hue/date_format.rs
@@ -122,6 +122,13 @@ pub mod local_opt {
     date_deserializer_local_opt!(DateTime<Local>, super::FORMAT_LOCAL);
 }
 
+pub mod legacy_utc {
+    use chrono::{DateTime, Utc};
+
+    date_serializer!(DateTime<Utc>, super::FORMAT_LOCAL);
+    date_deserializer_utc!(DateTime<Utc>, super::FORMAT_LOCAL);
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::{DateTime, TimeZone, Utc};

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -548,6 +548,7 @@ pub struct ApiScene {
     #[serde(rename = "type")]
     scene_type: ApiSceneType,
     lights: Vec<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
     lightstates: HashMap<String, ApiLightStateUpdate>,
     owner: Uuid,
     recycle: bool,
@@ -557,6 +558,7 @@ pub struct ApiScene {
     #[serde(with = "date_format::legacy_utc")]
     lastupdated: DateTime<Utc>,
     version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     image: Option<Uuid>,
     group: String,
 }

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -670,7 +670,6 @@ pub struct ApiSensor {
     pub capabilities: Value,
 }
 
-#[allow(clippy::zero_sized_map_values)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiUserConfig {
     pub config: ApiConfig,

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -226,9 +226,9 @@ impl SoftwareUpdate2 {
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Whitelist {
-    #[serde(with = "date_format::legacy_utc")]
+    #[serde(with = "date_format::legacy_utc", rename = "create date")]
     pub create_date: DateTime<Utc>,
-    #[serde(with = "date_format::legacy_utc")]
+    #[serde(with = "date_format::legacy_utc", rename = "last use date")]
     pub last_use_date: DateTime<Utc>,
     pub name: String,
 }

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -271,6 +271,7 @@ pub enum ApiEffect {
 #[serde(rename_all = "lowercase")]
 pub enum ApiAlert {
     None,
+    Select,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -288,8 +289,10 @@ pub struct ApiGroupAction {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ApiGroupType {
-    Room,
+    Entertainment,
     LightGroup,
+    Room,
+    Zone,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, net::Ipv4Addr};
 
 use chrono::{DateTime, Local, Utc};
 use mac_address::MacAddress;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
@@ -28,12 +28,25 @@ pub enum HueResult<T> {
     Error(HueError),
 }
 
+pub fn serialize_lower_case_mac<S>(mac: &MacAddress, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let m = mac.bytes();
+    let addr = format!(
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        m[0], m[1], m[2], m[3], m[4], m[5]
+    );
+    serializer.serialize_str(&addr)
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiShortConfig {
     pub apiversion: String,
     pub bridgeid: String,
     pub datastoreversion: String,
     pub factorynew: bool,
+    #[serde(serialize_with = "serialize_lower_case_mac")]
     pub mac: MacAddress,
     pub modelid: String,
     pub name: String,

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -194,6 +194,7 @@ impl Default for SwUpdate {
 #[serde(rename_all = "lowercase")]
 pub enum SwUpdateState {
     NoUpdates,
+    Transferring,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -370,12 +370,18 @@ pub enum LightColorMode {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiLightState {
     on: bool,
-    bri: u32,
-    hue: u32,
-    sat: u32,
-    effect: String,
-    xy: [f64; 2],
-    ct: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bri: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hue: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sat: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effect: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    xy: Option<[f64; 2]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ct: Option<u32>,
     alert: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     colormode: Option<LightColorMode>,
@@ -454,23 +460,12 @@ impl ApiLight {
         Self {
             state: ApiLightState {
                 on: light.on.on,
-                bri: light
-                    .dimming
-                    .map(|dim| (dim.brightness * 2.54) as u32)
-                    .unwrap_or_default(),
-                hue: 0,
-                sat: 0,
-                effect: String::new(),
-                xy: light
-                    .color
-                    .clone()
-                    .map(|col| col.xy.into())
-                    .unwrap_or_default(),
-                ct: light
-                    .color_temperature
-                    .clone()
-                    .and_then(|ct| ct.mirek)
-                    .unwrap_or_default(),
+                bri: light.dimming.map(|dim| (dim.brightness * 2.54) as u32),
+                hue: None,
+                sat: None,
+                effect: None,
+                xy: light.color.clone().map(|col| col.xy.into()),
+                ct: light.color_temperature.clone().and_then(|ct| ct.mirek),
                 alert: String::new(),
                 colormode: Some(colormode),
                 mode: "homeautomation".to_string(),

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -428,8 +428,10 @@ pub struct ApiLight {
     config: Value,
     uniqueid: String,
     swversion: String,
-    swconfigid: String,
-    productid: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    swconfigid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    productid: Option<String>,
 }
 
 impl ApiLight {
@@ -474,7 +476,7 @@ impl ApiLight {
             modelid: product_data.product_name,
             manufacturername: product_data.manufacturer_name,
             productname: "Hue color spot".to_string(),
-            productid: product_data.model_id,
+            productid: Some(product_data.model_id),
             capabilities: json!({
                 "certified": true,
                 "control": {
@@ -508,7 +510,7 @@ impl ApiLight {
             light_type: "Extended color light".to_string(),
             uniqueid: uuid.as_simple().to_string(),
             swversion: product_data.software_version,
-            swconfigid: String::new(),
+            swconfigid: None,
         }
     }
 }

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -176,7 +176,7 @@ pub struct DeviceTypes {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SwUpdate {
-    #[serde(with = "date_format::utc")]
+    #[serde(with = "date_format::legacy_utc")]
     lastinstall: DateTime<Utc>,
     state: SwUpdateState,
 }
@@ -201,7 +201,7 @@ pub struct SoftwareUpdate2 {
     autoinstall: Value,
     bridge: SwUpdate,
     checkforupdate: bool,
-    #[serde(with = "date_format::utc")]
+    #[serde(with = "date_format::legacy_utc")]
     lastchange: DateTime<Utc>,
     state: SwUpdateState,
 }
@@ -225,9 +225,9 @@ impl SoftwareUpdate2 {
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Whitelist {
-    #[serde(with = "date_format::utc")]
+    #[serde(with = "date_format::legacy_utc")]
     pub create_date: DateTime<Utc>,
-    #[serde(with = "date_format::utc")]
+    #[serde(with = "date_format::legacy_utc")]
     pub last_use_date: DateTime<Utc>,
     pub name: String,
 }
@@ -253,9 +253,9 @@ pub struct ApiConfig {
     pub netmask: Ipv4Addr,
     pub gateway: Ipv4Addr,
     pub timezone: String,
-    #[serde(with = "date_format::utc", rename = "UTC")]
+    #[serde(with = "date_format::legacy_utc", rename = "UTC")]
     pub utc: DateTime<Utc>,
-    #[serde(with = "date_format::local")]
+    #[serde(with = "date_format::legacy_local")]
     pub localtime: DateTime<Local>,
     pub whitelist: HashMap<Uuid, Whitelist>,
 }
@@ -531,7 +531,7 @@ pub struct ApiScene {
     locked: bool,
     appdata: ApiSceneAppData,
     picture: String,
-    #[serde(with = "date_format::utc")]
+    #[serde(with = "date_format::legacy_utc")]
     lastupdated: DateTime<Utc>,
     version: u32,
     image: Option<Uuid>,

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -516,7 +516,16 @@ impl ApiLight {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ApiResourceLink {}
+pub struct ApiResourceLink {
+    #[serde(rename = "type")]
+    pub link_type: String,
+    pub name: String,
+    pub description: String,
+    pub classid: u32,
+    pub owner: Uuid,
+    pub recycle: bool,
+    pub links: Vec<String>,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiRule {}

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -258,7 +258,7 @@ pub struct ApiConfig {
     pub utc: DateTime<Utc>,
     #[serde(with = "date_format::legacy_local")]
     pub localtime: DateTime<Local>,
-    pub whitelist: HashMap<Uuid, Whitelist>,
+    pub whitelist: HashMap<String, Whitelist>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -340,6 +340,11 @@ impl ApiGroup {
             },
             class: "Bedroom".to_string(),
             group_type: ApiGroupType::Room,
+            recycle: false,
+            sensors: vec![],
+            state: json!({}),
+            stream: Value::Null,
+            locations: Value::Null,
         }
     }
 }

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -550,7 +550,7 @@ pub struct ApiScene {
     lights: Vec<String>,
     #[serde(skip_serializing_if = "HashMap::is_empty", default)]
     lightstates: HashMap<String, ApiLightStateUpdate>,
-    owner: Uuid,
+    owner: String,
     recycle: bool,
     locked: bool,
     appdata: ApiSceneAppData,
@@ -590,7 +590,7 @@ impl ApiScene {
             scene_type: ApiSceneType::GroupScene,
             lights,
             lightstates,
-            owner,
+            owner: owner.to_string(),
             recycle: false,
             locked: false,
             /* Some clients (e.g. Hue Essentials) require .appdata */

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -528,7 +528,18 @@ pub struct ApiResourceLink {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ApiRule {}
+pub struct ApiRule {
+    pub name: String,
+    pub recycle: bool,
+    pub status: String,
+    pub conditions: Vec<Value>,
+    pub actions: Vec<Value>,
+    pub owner: Uuid,
+    pub timestriggered: u32,
+    #[serde(with = "date_format::legacy_utc")]
+    pub created: DateTime<Utc>,
+    pub lasttriggered: String,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ApiSceneType {

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -284,7 +284,8 @@ pub struct ApiGroupAction {
     xy: [f64; 2],
     ct: u32,
     alert: ApiAlert,
-    colormode: LightColorMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    colormode: Option<LightColorMode>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -336,7 +337,7 @@ impl ApiGroup {
                 xy: [0.0, 0.0],
                 ct: 0,
                 alert: ApiAlert::None,
-                colormode: LightColorMode::Xy,
+                colormode: None,
             },
             class: "Bedroom".to_string(),
             group_type: ApiGroupType::Room,
@@ -373,7 +374,8 @@ pub struct ApiLightState {
     xy: [f64; 2],
     ct: u32,
     alert: String,
-    colormode: LightColorMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    colormode: Option<LightColorMode>,
     mode: String,
     reachable: bool,
 }
@@ -467,7 +469,7 @@ impl ApiLight {
                     .and_then(|ct| ct.mirek)
                     .unwrap_or_default(),
                 alert: String::new(),
-                colormode,
+                colormode: Some(colormode),
                 mode: "homeautomation".to_string(),
                 reachable: true,
             },

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -355,6 +355,7 @@ pub struct ApiGroupState {
 pub enum LightColorMode {
     Ct,
     Xy,
+    Hs,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -626,7 +626,25 @@ impl ApiScene {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ApiSchedule {}
+pub struct ApiSchedule {
+    pub recycle: bool,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autodelete: Option<bool>,
+    pub description: String,
+    pub command: Value,
+    #[serde(with = "date_format::legacy_utc")]
+    pub created: DateTime<Utc>,
+    #[serde(
+        with = "date_format::legacy_utc_opt",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub starttime: Option<DateTime<Utc>>,
+    pub time: String,
+    pub localtime: String,
+    pub status: String,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiSensor {}

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -277,12 +277,18 @@ pub enum ApiAlert {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiGroupAction {
     on: bool,
-    bri: u32,
-    hue: u32,
-    sat: u32,
-    effect: ApiEffect,
-    xy: [f64; 2],
-    ct: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bri: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hue: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sat: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effect: Option<ApiEffect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    xy: Option<[f64; 2]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ct: Option<u32>,
     alert: ApiAlert,
     #[serde(skip_serializing_if = "Option::is_none")]
     colormode: Option<LightColorMode>,
@@ -327,15 +333,12 @@ impl ApiGroup {
             lights,
             action: ApiGroupAction {
                 on: glight.on.is_some_and(|on| on.on),
-                bri: glight
-                    .dimming
-                    .map(|dim| (dim.brightness * 2.54) as u32)
-                    .unwrap_or_default(),
-                hue: 0,
-                sat: 0,
-                effect: ApiEffect::None,
-                xy: [0.0, 0.0],
-                ct: 0,
+                bri: glight.dimming.map(|dim| (dim.brightness * 2.54) as u32),
+                hue: None,
+                sat: None,
+                effect: None,
+                xy: None,
+                ct: None,
                 alert: ApiAlert::None,
                 colormode: None,
             },

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -560,7 +560,8 @@ pub struct ApiScene {
     version: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     image: Option<Uuid>,
-    group: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    group: Option<String>,
 }
 
 impl ApiScene {
@@ -601,7 +602,7 @@ impl ApiScene {
             lastupdated: Utc::now(),
             version: ApiSceneVersion::V2 as u32,
             image: scene.metadata.image.map(|rl| rl.rid),
-            group: room_id.to_string(),
+            group: Some(room_id.to_string()),
         })
     }
 }

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -304,6 +304,13 @@ pub struct ApiGroup {
     #[serde(rename = "type")]
     group_type: ApiGroupType,
     class: String,
+    recycle: bool,
+    sensors: Vec<Value>,
+    state: Value,
+    #[serde(skip_serializing_if = "Value::is_null", default)]
+    stream: Value,
+    #[serde(skip_serializing_if = "Value::is_null", default)]
+    locations: Value,
 }
 
 impl ApiGroup {

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -647,7 +647,28 @@ pub struct ApiSchedule {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ApiSensor {}
+pub struct ApiSensor {
+    #[serde(rename = "type")]
+    pub sensor_type: String,
+    pub config: Value,
+    pub name: String,
+    pub state: Value,
+    pub manufacturername: String,
+    pub modelid: String,
+    pub swversion: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub swupdate: Option<SwUpdate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uniqueid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diversityid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub productname: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recycle: Option<bool>,
+    #[serde(skip_serializing_if = "Value::is_null", default)]
+    pub capabilities: Value,
+}
 
 #[allow(clippy::zero_sized_map_values)]
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -536,8 +536,10 @@ pub enum ApiSceneVersion {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiSceneAppData {
-    pub data: String,
-    pub version: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<u8>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -590,8 +592,8 @@ impl ApiScene {
             locked: false,
             /* Some clients (e.g. Hue Essentials) require .appdata */
             appdata: ApiSceneAppData {
-                data: format!("xxxxx_r{room_id}"),
-                version: 1,
+                data: Some(format!("xxxxx_r{room_id}")),
+                version: Some(1),
             },
             picture: String::new(),
             lastupdated: Utc::now(),

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -351,6 +351,7 @@ impl Resources {
             | Resource::LightLevel(_)
             | Resource::Matter(_)
             | Resource::Motion(_)
+            | Resource::PrivateGroup(_)
             | Resource::PublicImage(_)
             | Resource::RelativeRotary(_)
             | Resource::SmartScene(_)

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -9,8 +9,8 @@ use uuid::Uuid;
 
 use crate::error::{ApiError, ApiResult};
 use crate::hue::api::{
-    Bridge, BridgeHome, Device, DeviceArchetype, DeviceProductData, Identify, Metadata, RType,
-    Resource, ResourceLink, ResourceRecord, TimeZone, ZigbeeConnectivity, ZigbeeConnectivityStatus,
+    Bridge, BridgeHome, Device, DeviceArchetype, DeviceProductData, Metadata, RType, Resource,
+    ResourceLink, ResourceRecord, TimeZone, ZigbeeConnectivity, ZigbeeConnectivityStatus,
     ZigbeeDeviceDiscovery,
 };
 use crate::hue::api::{GroupedLightUpdate, LightUpdate, SceneUpdate, Update};
@@ -206,7 +206,8 @@ impl Resources {
             product_data: DeviceProductData::hue_bridge_v2(&self.version),
             metadata: Metadata::new(DeviceArchetype::BridgeV2, "Bifrost"),
             services: vec![link_bridge, link_zbdd, link_zbc],
-            identify: Identify {},
+            identify: None,
+            usertest: None,
         };
 
         let bridge = Bridge {
@@ -219,7 +220,8 @@ impl Resources {
             product_data: DeviceProductData::hue_bridge_v2(&self.version),
             metadata: Metadata::new(DeviceArchetype::BridgeV2, "Bifrost Bridge Home"),
             services: vec![link_bridge],
-            identify: Identify {},
+            identify: None,
+            usertest: None,
         };
 
         let bridge_home = BridgeHome {

--- a/src/server/appstate.rs
+++ b/src/server/appstate.rs
@@ -103,7 +103,7 @@ impl AppState {
             gateway: self.conf.bridge.gateway,
             timezone: self.conf.bridge.timezone.clone(),
             whitelist: HashMap::from([(
-                username,
+                username.to_string(),
                 Whitelist {
                     create_date: Utc::now(),
                     last_use_date: Utc::now(),

--- a/src/z2m/mod.rs
+++ b/src/z2m/mod.rs
@@ -357,6 +357,7 @@ impl Client {
                         color_temperature,
                         dimming: light.as_dimming_opt(),
                         on: Some(light.on),
+                        gradient: None,
                     },
                 );
             }

--- a/src/z2m/mod.rs
+++ b/src/z2m/mod.rs
@@ -90,7 +90,8 @@ impl Client {
             product_data,
             metadata: metadata.clone(),
             services: vec![link_light],
-            identify: Identify {},
+            identify: None,
+            usertest: None,
         };
 
         self.map.insert(name.to_string(), link_light.rid);
@@ -133,7 +134,8 @@ impl Client {
             product_data: DeviceProductData::guess_from_device(dev),
             metadata: Metadata::new(DeviceArchetype::UnknownArchetype, "foo"),
             services: vec![link_button, link_zbc],
-            identify: Identify {},
+            identify: None,
+            usertest: None,
         };
 
         self.map.insert(name.to_string(), link_button.rid);

--- a/src/z2m/mod.rs
+++ b/src/z2m/mod.rs
@@ -144,6 +144,7 @@ impl Client {
             owner: link_device,
             metadata: ButtonMetadata { control_id: 0 },
             button: ButtonData {
+                last_event: None,
                 button_report: Some(ButtonReport {
                     updated: Utc::now(),
                     event: String::from("initial_press"),

--- a/src/z2m/mod.rs
+++ b/src/z2m/mod.rs
@@ -23,7 +23,7 @@ use crate::hue;
 use crate::hue::api::{
     Button, ButtonData, ButtonMetadata, ButtonReport, ColorTemperature, ColorTemperatureUpdate,
     ColorUpdate, Device, DeviceArchetype, DeviceProductData, Dimming, DimmingUpdate, GroupedLight,
-    Identify, Light, LightColor, LightUpdate, Metadata, RType, Resource, ResourceLink, Room,
+    Light, LightColor, LightMetadata, LightUpdate, Metadata, RType, Resource, ResourceLink, Room,
     RoomArchetype, RoomMetadata, Scene, SceneAction, SceneActionElement, SceneMetadata,
     SceneRecall, SceneStatus, ZigbeeConnectivity, ZigbeeConnectivityStatus,
 };
@@ -84,11 +84,11 @@ impl Client {
         let link_light = RType::Light.deterministic(&dev.ieee_address);
 
         let product_data = DeviceProductData::guess_from_device(dev);
-        let metadata = Metadata::new(DeviceArchetype::SpotBulb, name);
+        let metadata = LightMetadata::new(DeviceArchetype::SpotBulb, name);
 
         let dev = hue::api::Device {
             product_data,
-            metadata: metadata.clone(),
+            metadata: metadata.clone().into(),
             services: vec![link_light],
             identify: None,
             usertest: None,

--- a/src/z2m/mod.rs
+++ b/src/z2m/mod.rs
@@ -358,6 +358,7 @@ impl Client {
                         dimming: light.as_dimming_opt(),
                         on: Some(light.on),
                         gradient: None,
+                        effects: json!({}),
                     },
                 );
             }


### PR DESCRIPTION
This MR integrates a large number of fixes for the Hue Api model.

It is based on testing the API models on real-world data samples provided by volunteers.

Thanks to @hendriksen-mark @tbgoose @anderstrier @joeblack2k and others for providing sample data for testing.

Also new in this MR is the program `examples/normalize-hue-get.rs`, which reads data dumps from hue bridges, and encodes/decodes them through the Bifrost hue api models.

Anything that does not come out exactly the same, is reported as an error.

This has helped tremendously in finding weird edge cases in the api models.