### PR TITLE
Self updates

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
     # Publish semver tags as releases.
     tags: [ "v*.*.*", "dev*" ]
 #  pull_request:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -176,7 +177,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -230,11 +231,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.12",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
- "tower",
+ "tokio-rustls 0.24.1",
+ "tower 0.4.13",
  "tower-service",
 ]
 
@@ -298,6 +299,7 @@ dependencies = [
  "pretty_env_logger",
  "rand",
  "rand_core",
+ "reqwest",
  "rsa",
  "rustls-pemfile",
  "serde",
@@ -310,7 +312,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
  "uuid",
@@ -385,6 +387,12 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -561,6 +569,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +617,15 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -917,21 +945,44 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls 0.23.13",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
  "pin-project-lite",
+ "socket2",
  "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -958,6 +1009,145 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "if-addrs"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +1166,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is-terminal"
@@ -1054,6 +1250,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1150,6 +1352,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,7 +1376,7 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "libc",
  "memoffset",
 ]
@@ -1374,6 +1593,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.13",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.13",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1710,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "reqwest"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.13",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower 0.5.2",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "windows-registry",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,6 +1804,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+
+[[package]]
 name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,8 +1817,22 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1527,6 +1858,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -1730,6 +2072,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,6 +2111,20 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "termcolor"
@@ -1792,6 +2154,31 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls_codec"
@@ -1847,7 +2234,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.13",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -1902,6 +2300,21 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1966,6 +2379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tungstenite"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,10 +2421,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2029,6 +2471,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2063,6 +2514,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2553,25 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -2128,6 +2610,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -2280,6 +2792,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "x509-cert"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2824,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -2324,6 +2872,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2906,28 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ server-banner = ["server", "dep:termcolor", "dep:itertools"]
 
 [dependencies]
 async-stream = "0.3.5"
-axum = { version = "0.7.5", features = ["macros"] }
+axum = { version = "0.7.5", features = ["macros", "multipart"] }
 axum-core = "0.4.3"
 axum-server = { version = "0.6.0", features = ["rustls", "tls-rustls"] }
 bytes = "1.7.1"
@@ -68,3 +68,4 @@ sha1 = "0.10.6"
 rustls-pemfile = "2.1.3"
 termcolor = { version = "1.4.1", optional = true }
 itertools = { version = "0.13.0", optional = true }
+reqwest = { version = "0.12.8", default-features = false, features = ["__tls", "json", "rustls-tls"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,6 +78,9 @@ pub enum ApiError {
     #[error(transparent)]
     P256Pkcs8Error(#[from] p256::pkcs8::Error),
 
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
+
     /* zigbee2mqtt errors */
     #[error("Unexpected eof on z2m socket")]
     UnexpectedZ2mEof,
@@ -101,6 +104,9 @@ pub enum ApiError {
 
     #[error("Resource {0} not found")]
     NotFound(Uuid),
+
+    #[error("Failed to get firmware version reply from update server")]
+    NoUpdateInformation,
 
     #[error("Resource type wrong: expected {0:?} but found {1:?}")]
     WrongType(RType, RType),

--- a/src/hue/api/device.rs
+++ b/src/hue/api/device.rs
@@ -67,7 +67,7 @@ impl DeviceProductData {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum DeviceArchetype {
     BridgeV2,

--- a/src/hue/api/device.rs
+++ b/src/hue/api/device.rs
@@ -40,7 +40,7 @@ impl DeviceProductData {
             model_id: HUE_BRIDGE_V2_MODEL_ID.to_string(),
             product_archetype: DeviceArchetype::BridgeV2,
             product_name: "Hue Bridge".to_string(),
-            software_version: version.get_apiversion(),
+            software_version: version.get_software_version(),
         }
     }
 

--- a/src/hue/api/device.rs
+++ b/src/hue/api/device.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::hue::api::{Metadata, RType, ResourceLink};
+use crate::hue::version::SwVersion;
+use crate::hue::HUE_BRIDGE_V2_MODEL_ID;
 use crate::z2m;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -31,14 +33,14 @@ impl DeviceProductData {
     const SIGNIFY_MANUFACTURER_NAME: &'static str = "Signify Netherlands B.V.";
 
     #[must_use]
-    pub fn hue_bridge_v2() -> Self {
+    pub fn hue_bridge_v2(version: &SwVersion) -> Self {
         Self {
             certified: true,
             manufacturer_name: Self::SIGNIFY_MANUFACTURER_NAME.to_string(),
-            model_id: "BSB002".to_string(),
+            model_id: HUE_BRIDGE_V2_MODEL_ID.to_string(),
             product_archetype: DeviceArchetype::BridgeV2,
             product_name: "Hue Bridge".to_string(),
-            software_version: "1.66.1966060010".to_string(),
+            software_version: version.get_apiversion(),
         }
     }
 

--- a/src/hue/api/device.rs
+++ b/src/hue/api/device.rs
@@ -44,15 +44,15 @@ impl DeviceProductData {
 
     #[must_use]
     pub fn guess_from_device(dev: &z2m::api::Device) -> Self {
-        fn str_or_unknown(name: &Option<String>) -> String {
-            name.clone().unwrap_or_else(|| String::from("<unknown>"))
+        fn str_or_unknown(name: Option<&String>) -> String {
+            name.cloned().unwrap_or_else(|| String::from("<unknown>"))
         }
 
-        let product_name = str_or_unknown(&dev.model_id);
-        let model_id = str_or_unknown(&dev.definition.as_ref().map(|def| def.model.clone()));
-        let manufacturer_name = str_or_unknown(&dev.manufacturer);
+        let product_name = str_or_unknown(dev.model_id.as_ref());
+        let model_id = str_or_unknown(dev.definition.as_ref().map(|def| &def.model));
+        let manufacturer_name = str_or_unknown(dev.manufacturer.as_ref());
         let certified = manufacturer_name == Self::SIGNIFY_MANUFACTURER_NAME;
-        let software_version = str_or_unknown(&dev.software_build_id);
+        let software_version = str_or_unknown(dev.software_build_id.as_ref());
 
         let product_archetype = DeviceArchetype::SpotBulb;
 

--- a/src/hue/api/resource.rs
+++ b/src/hue/api/resource.rs
@@ -70,12 +70,8 @@ pub struct ResourceRecord {
 
 impl ResourceRecord {
     #[must_use]
-    pub fn new(id: Uuid, id_v1: Option<String>, res: &Resource) -> Self {
-        Self {
-            id,
-            id_v1,
-            obj: res.clone(),
-        }
+    pub const fn new(id: Uuid, id_v1: Option<String>, obj: Resource) -> Self {
+        Self { id, id_v1, obj }
     }
 }
 

--- a/src/hue/date_format.rs
+++ b/src/hue/date_format.rs
@@ -1,4 +1,19 @@
 const FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
+const UPDATE_FORMAT: &str = "%+";
+
+pub mod update_utc {
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use serde::{self, de::Error, Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let dt = NaiveDateTime::parse_from_str(&s, super::UPDATE_FORMAT).map_err(Error::custom)?;
+        Ok(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))
+    }
+}
 
 pub mod utc {
     use chrono::{DateTime, NaiveDateTime, Utc};

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -7,7 +7,7 @@ use serde_json::{json, Value};
 use uuid::Uuid;
 
 use crate::error::ApiResult;
-use crate::hue::{api, best_guess_timezone};
+use crate::hue::{self, api, best_guess_timezone};
 use crate::resource::Resources;
 
 use super::date_format;
@@ -44,16 +44,16 @@ pub struct ApiShortConfig {
 impl Default for ApiShortConfig {
     fn default() -> Self {
         Self {
-            apiversion: "1.66.0".to_string(),
+            apiversion: hue::HUE_BRIDGE_V2_DEFAULT_APIVERSION.to_string(),
             bridgeid: "0000000000000000".to_string(),
             datastoreversion: "163".to_string(),
             factorynew: false,
             mac: MacAddress::default(),
-            modelid: crate::hue::HUE_BRIDGE_V2_MODEL_ID.to_string(),
+            modelid: hue::HUE_BRIDGE_V2_MODEL_ID.to_string(),
             name: "Bifrost Bridge".to_string(),
             replacesbridgeid: None,
             starterkitid: String::new(),
-            swversion: "1966060010".to_string(),
+            swversion: hue::HUE_BRIDGE_V2_DEFAULT_SWVERSION.to_string(),
         }
     }
 }

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -7,6 +7,7 @@ use serde_json::{json, Value};
 use uuid::Uuid;
 
 use crate::error::ApiResult;
+use crate::hue::version::SwVersion;
 use crate::hue::{self, api, best_guess_timezone};
 use crate::resource::Resources;
 
@@ -54,6 +55,19 @@ impl Default for ApiShortConfig {
             replacesbridgeid: None,
             starterkitid: String::new(),
             swversion: hue::HUE_BRIDGE_V2_DEFAULT_SWVERSION.to_string(),
+        }
+    }
+}
+
+impl ApiShortConfig {
+    #[must_use]
+    pub fn from_mac_and_version(mac: MacAddress, version: &SwVersion) -> Self {
+        Self {
+            bridgeid: hue::bridge_id(mac),
+            apiversion: version.get_legacy_apiversion(),
+            swversion: version.get_apiversion(),
+            mac,
+            ..Self::default()
         }
     }
 }

--- a/src/hue/legacy_api.rs
+++ b/src/hue/legacy_api.rs
@@ -65,7 +65,7 @@ impl ApiShortConfig {
         Self {
             bridgeid: hue::bridge_id(mac),
             apiversion: version.get_legacy_apiversion(),
-            swversion: version.get_apiversion(),
+            swversion: version.get_legacy_swversion(),
             mac,
             ..Self::default()
         }

--- a/src/hue/mod.rs
+++ b/src/hue/mod.rs
@@ -1,3 +1,5 @@
+use mac_address::MacAddress;
+
 pub mod api;
 pub mod date_format;
 pub mod event;
@@ -9,4 +11,20 @@ pub const HUE_BRIDGE_V2_MODEL_ID: &str = "BSB002";
 #[must_use]
 pub fn best_guess_timezone() -> String {
     iana_time_zone::get_timezone().unwrap_or_else(|_| "none".to_string())
+}
+
+#[must_use]
+pub fn bridge_id_raw(mac: MacAddress) -> [u8; 8] {
+    let b = mac.bytes();
+    [b[0], b[1], b[2], 0xFF, 0xFE, b[3], b[4], b[5]]
+}
+
+#[must_use]
+#[allow(clippy::format_collect)]
+pub fn bridge_id(mac: MacAddress) -> String {
+    let bytes = bridge_id_raw(mac);
+    bytes
+        .into_iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>()
 }

--- a/src/hue/mod.rs
+++ b/src/hue/mod.rs
@@ -7,6 +7,8 @@ pub mod legacy_api;
 pub mod scene_icons;
 
 pub const HUE_BRIDGE_V2_MODEL_ID: &str = "BSB002";
+pub const HUE_BRIDGE_V2_DEFAULT_SWVERSION: u64 = 1_968_096_020;
+pub const HUE_BRIDGE_V2_DEFAULT_APIVERSION: &str = "1.68.0";
 
 #[must_use]
 pub fn best_guess_timezone() -> String {

--- a/src/hue/mod.rs
+++ b/src/hue/mod.rs
@@ -5,6 +5,7 @@ pub mod date_format;
 pub mod event;
 pub mod legacy_api;
 pub mod scene_icons;
+pub mod version;
 
 pub const HUE_BRIDGE_V2_MODEL_ID: &str = "BSB002";
 pub const HUE_BRIDGE_V2_DEFAULT_SWVERSION: u64 = 1_968_096_020;

--- a/src/hue/mod.rs
+++ b/src/hue/mod.rs
@@ -5,6 +5,7 @@ pub mod date_format;
 pub mod event;
 pub mod legacy_api;
 pub mod scene_icons;
+pub mod update;
 pub mod version;
 
 pub const HUE_BRIDGE_V2_MODEL_ID: &str = "BSB002";

--- a/src/hue/update.rs
+++ b/src/hue/update.rs
@@ -1,0 +1,39 @@
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::error::ApiResult;
+use crate::hue::{date_format, HUE_BRIDGE_V2_MODEL_ID};
+
+// Full request goes to {UPDATE_CHECK_URL}?deviceTypeId=BSB002&version=1
+pub const UPDATE_CHECK_URL: &str = "https://firmware.meethue.com/v1/checkupdate";
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateEntry {
+    #[serde(with = "date_format::update_utc")]
+    pub created_at: DateTime<Utc>,
+    #[serde(with = "date_format::update_utc")]
+    pub updated_at: DateTime<Utc>,
+    pub file_size: u64,
+    pub md5: String,
+    pub binary_url: String,
+    pub version: u64,
+    pub version_name: String,
+    pub release_notes: String,
+}
+
+#[derive(Deserialize)]
+struct UpdateEntries {
+    updates: Vec<UpdateEntry>,
+}
+
+#[must_use]
+pub fn update_url_for_bridge(device_type_id: &str, version: u64) -> String {
+    format!("{UPDATE_CHECK_URL}?deviceTypeId={device_type_id}&version={version}")
+}
+
+pub async fn fetch_updates(since_version: Option<u64>) -> ApiResult<Vec<UpdateEntry>> {
+    let url = update_url_for_bridge(HUE_BRIDGE_V2_MODEL_ID, since_version.unwrap_or_default());
+    let response: UpdateEntries = reqwest::get(url).await?.json().await?;
+    Ok(response.updates)
+}

--- a/src/hue/version.rs
+++ b/src/hue/version.rs
@@ -48,7 +48,13 @@ impl SwVersion {
 
     #[must_use]
     pub fn get_legacy_apiversion(&self) -> String {
-        self.name.to_string()
+        let version = format!("{:05}", self.version);
+        format!("{}.{}.0", &version[0..1], &version[2..4])
+    }
+
+    #[must_use]
+    pub fn get_legacy_swversion(&self) -> String {
+        format!("{}", &self.version)
     }
 
     #[must_use]
@@ -65,7 +71,7 @@ impl SwVersion {
     ///   1.68.1968096020
     ///     ^^^^^^^^^^ append whole version number at the end
     /// ```
-    pub fn get_apiversion(&self) -> String {
+    pub fn get_software_version(&self) -> String {
         let version = format!("{:05}", self.version);
         format!("{}.{}.{}", &version[0..1], &version[2..4], version)
     }

--- a/src/hue/version.rs
+++ b/src/hue/version.rs
@@ -62,7 +62,7 @@ impl SwVersion {
     ///
     /// Legacy version is constructed from the version number.
     ///
-    /// ```
+    /// ```text
     /// Example:
     ///   1968096020
     ///

--- a/src/hue/version.rs
+++ b/src/hue/version.rs
@@ -1,0 +1,72 @@
+use std::fmt::Debug;
+
+use crate::hue::{HUE_BRIDGE_V2_DEFAULT_APIVERSION, HUE_BRIDGE_V2_DEFAULT_SWVERSION};
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct SwVersion {
+    version: u64,
+    name: String,
+}
+
+impl PartialOrd for SwVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SwVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.version.cmp(&other.version)
+    }
+}
+
+impl Default for SwVersion {
+    fn default() -> Self {
+        Self {
+            version: HUE_BRIDGE_V2_DEFAULT_SWVERSION,
+            name: HUE_BRIDGE_V2_DEFAULT_APIVERSION.to_string(),
+        }
+    }
+}
+
+impl Debug for SwVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ({})", self.name, self.version)
+    }
+}
+
+impl SwVersion {
+    #[must_use]
+    pub const fn new(version: u64, name: String) -> Self {
+        Self { version, name }
+    }
+
+    #[must_use]
+    pub const fn as_u64(&self) -> u64 {
+        self.version
+    }
+
+    #[must_use]
+    pub fn get_legacy_apiversion(&self) -> String {
+        self.name.to_string()
+    }
+
+    #[must_use]
+    /// Format a version into the hue legacy format
+    ///
+    /// Legacy version is constructed from the version number.
+    ///
+    /// ```
+    /// Example:
+    ///   1968096020
+    ///
+    ///   1_68______ (these digits used)
+    ///
+    ///   1.68.1968096020
+    ///     ^^^^^^^^^^ append whole version number at the end
+    /// ```
+    pub fn get_apiversion(&self) -> String {
+        let version = format!("{:05}", self.version);
+        format!("{}.{}.{}", &version[0..1], &version[2..4], version)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,10 @@ async fn build_tasks(appstate: AppState) -> ApiResult<JoinSet<ApiResult<()>>> {
         tls_config,
     ));
     tasks.spawn(server::config_writer(appstate.res.clone(), state_file));
+    tasks.spawn(server::version_updater(
+        appstate.res.clone(),
+        appstate.updater(),
+    ));
 
     for (name, server) in &appstate.config().z2m.servers {
         let client = z2m::Client::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ async fn run() -> ApiResult<()> {
     let config = config::parse("config.yaml".into())?;
     log::debug!("Configuration loaded successfully");
 
-    let appstate = AppState::from_config(config)?;
+    let appstate = AppState::from_config(config).await?;
 
     let mut tasks = build_tasks(appstate).await?;
 

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -5,7 +5,6 @@ use mdns_sd::{ServiceDaemon, ServiceInfo};
 
 use crate::error::ApiResult;
 use crate::hue;
-use crate::server::certificate;
 
 pub fn register_mdns(mac: MacAddress, ip: Ipv4Addr) -> ApiResult<ServiceDaemon> {
     /* Create a new mDNS daemon. */
@@ -24,7 +23,7 @@ pub fn register_mdns(mac: MacAddress, ip: Ipv4Addr) -> ApiResult<ServiceDaemon> 
 
     let properties = [
         ("modelid", hue::HUE_BRIDGE_V2_MODEL_ID),
-        ("bridgeid", &certificate::hue_bridge_id(mac)),
+        ("bridgeid", &hue::bridge_id(mac)),
     ];
 
     let service_info = ServiceInfo::new(

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -43,6 +43,12 @@ impl Resources {
         }
     }
 
+    pub fn update_bridge_version(&mut self, version: SwVersion) {
+        self.version = version;
+        self.state.patch_bridge_version(&self.version);
+        self.state_updates.notify_one();
+    }
+
     pub fn read(&mut self, rdr: impl Read) -> ApiResult<()> {
         self.state = State::from_reader(rdr)?;
         Ok(())

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -15,12 +15,14 @@ use crate::hue::api::{
 };
 use crate::hue::api::{GroupedLightUpdate, LightUpdate, SceneUpdate, Update};
 use crate::hue::event::EventBlock;
+use crate::hue::version::SwVersion;
 use crate::model::state::{AuxData, State};
 use crate::z2m::request::ClientRequest;
 
 #[derive(Clone, Debug)]
 pub struct Resources {
     state: State,
+    version: SwVersion,
     state_updates: Arc<Notify>,
     pub hue_updates: Sender<EventBlock>,
     pub z2m_updates: Sender<Arc<ClientRequest>>,
@@ -31,9 +33,10 @@ impl Resources {
 
     #[allow(clippy::new_without_default)]
     #[must_use]
-    pub fn new(state: State) -> Self {
+    pub fn new(version: SwVersion, state: State) -> Self {
         Self {
             state,
+            version,
             state_updates: Arc::new(Notify::new()),
             hue_updates: Sender::new(32),
             z2m_updates: Sender::new(32),
@@ -194,7 +197,7 @@ impl Resources {
         let link_zbc = RType::ZigbeeConnectivity.deterministic(link_bridge.rid);
 
         let bridge_dev = Device {
-            product_data: DeviceProductData::hue_bridge_v2(),
+            product_data: DeviceProductData::hue_bridge_v2(&self.version),
             metadata: Metadata::new(DeviceArchetype::BridgeV2, "Bifrost"),
             services: vec![link_bridge, link_zbdd, link_zbc],
         };
@@ -206,7 +209,7 @@ impl Resources {
         };
 
         let bridge_home_dev = Device {
-            product_data: DeviceProductData::hue_bridge_v2(),
+            product_data: DeviceProductData::hue_bridge_v2(&self.version),
             metadata: Metadata::new(DeviceArchetype::BridgeV2, "Bifrost Bridge Home"),
             services: vec![link_bridge],
         };

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -339,7 +339,7 @@ impl Resources {
     }
 
     fn make_resource_record(&self, id: &Uuid, res: &Resource) -> ResourceRecord {
-        ResourceRecord::new(*id, self.id_v1_scope(id, res), res)
+        ResourceRecord::new(*id, self.id_v1_scope(id, res), res.clone())
     }
 
     pub fn get_resource(&self, ty: RType, id: &Uuid) -> ApiResult<ResourceRecord> {

--- a/src/routes/api.rs
+++ b/src/routes/api.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 async fn get_api_config(State(state): State<AppState>) -> impl IntoResponse {
-    Json(state.api_short_config())
+    Json(state.api_short_config().await)
 }
 
 async fn post_api(bytes: Bytes) -> ApiResult<impl IntoResponse> {
@@ -108,7 +108,7 @@ async fn get_api_user(
     let lock = state.res.lock().await;
 
     Ok(Json(ApiUserConfig {
-        config: state.api_config(username),
+        config: state.api_config(username).await,
         groups: get_groups(&lock)?,
         lights: get_lights(&lock)?,
         resourcelinks: HashMap::new(),
@@ -125,7 +125,7 @@ async fn get_api_user_resource(
 ) -> ApiResult<Json<Value>> {
     let lock = &state.res.lock().await;
     match resource {
-        ApiResourceType::Config => Ok(Json(json!(state.api_config(username)))),
+        ApiResourceType::Config => Ok(Json(json!(state.api_config(username).await))),
         ApiResourceType::Lights => Ok(Json(json!(get_lights(lock)?))),
         ApiResourceType::Groups => Ok(Json(json!(get_groups(lock)?))),
         ApiResourceType::Scenes => Ok(Json(json!(get_scenes(&username, lock)?))),

--- a/src/server/appstate.rs
+++ b/src/server/appstate.rs
@@ -55,7 +55,7 @@ impl AppState {
         } else {
             log::debug!("No state file found, initializing..");
             res = Resources::new(State::new());
-            res.init(&server::certificate::hue_bridge_id(config.bridge.mac))?;
+            res.init(&hue::bridge_id(config.bridge.mac))?;
         }
 
         let conf = Arc::new(config);

--- a/src/server/appstate.rs
+++ b/src/server/appstate.rs
@@ -10,19 +10,22 @@ use uuid::Uuid;
 
 use crate::config::AppConfig;
 use crate::error::{ApiError, ApiResult};
+use crate::hue;
 use crate::hue::legacy_api::{ApiConfig, ApiShortConfig, Whitelist};
 use crate::model::state::{State, StateVersion};
 use crate::resource::Resources;
-use crate::server::{self, certificate};
+use crate::server::certificate;
+use crate::server::updater::VersionUpdater;
 
 #[derive(Clone)]
 pub struct AppState {
     conf: Arc<AppConfig>,
+    upd: Arc<Mutex<VersionUpdater>>,
     pub res: Arc<Mutex<Resources>>,
 }
 
 impl AppState {
-    pub fn from_config(config: AppConfig) -> ApiResult<Self> {
+    pub async fn from_config(config: AppConfig) -> ApiResult<Self> {
         let certfile = &config.bifrost.cert_file;
 
         let certpath = Utf8Path::new(certfile);
@@ -34,6 +37,8 @@ impl AppState {
         }
 
         let mut res;
+        let upd = Arc::new(Mutex::new(VersionUpdater::new()));
+        let swversion = upd.lock().await.get().await.clone();
 
         if let Ok(fd) = File::open(&config.bifrost.state_file) {
             log::debug!("Existing state file found, loading..");
@@ -51,17 +56,17 @@ impl AppState {
                     State::from_v1(yaml)?
                 }
             };
-            res = Resources::new(state);
+            res = Resources::new(swversion, state);
         } else {
             log::debug!("No state file found, initializing..");
-            res = Resources::new(State::new());
+            res = Resources::new(swversion, State::new());
             res.init(&hue::bridge_id(config.bridge.mac))?;
         }
 
         let conf = Arc::new(config);
         let res = Arc::new(Mutex::new(res));
 
-        Ok(Self { conf, res })
+        Ok(Self { conf, upd, res })
     }
 
     pub async fn tls_config(&self) -> ApiResult<RustlsConfig> {
@@ -79,19 +84,20 @@ impl AppState {
     }
 
     #[must_use]
-    pub fn api_short_config(&self) -> ApiShortConfig {
-        let mac = self.conf.bridge.mac;
-        ApiShortConfig {
-            bridgeid: certificate::hue_bridge_id(mac),
-            mac,
-            ..Default::default()
-        }
+    pub fn updater(&self) -> Arc<Mutex<VersionUpdater>> {
+        self.upd.clone()
     }
 
     #[must_use]
-    pub fn api_config(&self, username: Uuid) -> ApiConfig {
+    pub async fn api_short_config(&self) -> ApiShortConfig {
+        let mac = self.conf.bridge.mac;
+        ApiShortConfig::from_mac_and_version(mac, self.upd.lock().await.get().await)
+    }
+
+    #[must_use]
+    pub async fn api_config(&self, username: Uuid) -> ApiConfig {
         ApiConfig {
-            short_config: self.api_short_config(),
+            short_config: self.api_short_config().await,
             ipaddress: self.conf.bridge.ipaddress,
             netmask: self.conf.bridge.netmask,
             gateway: self.conf.bridge.gateway,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,7 @@
 pub mod appstate;
 pub mod banner;
 pub mod certificate;
+pub mod updater;
 
 use std::fs::File;
 use std::io::Write;

--- a/src/server/updater.rs
+++ b/src/server/updater.rs
@@ -1,0 +1,68 @@
+use chrono::{DateTime, Duration, Utc};
+
+use crate::error::{ApiError, ApiResult};
+use crate::hue::update;
+use crate::hue::version::SwVersion;
+
+#[derive(Debug)]
+pub struct VersionUpdater {
+    version: Option<SwVersion>,
+    last_fetch: Option<DateTime<Utc>>,
+}
+
+impl Default for VersionUpdater {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VersionUpdater {
+    const CACHE_TIME: Duration = Duration::hours(24);
+
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            version: None,
+            last_fetch: None,
+        }
+    }
+
+    pub async fn fetch_version(&mut self) -> ApiResult<SwVersion> {
+        update::fetch_updates(None)
+            .await?
+            .into_iter()
+            .max_by(|x, y| x.version.cmp(&y.version))
+            .map(|max| SwVersion::new(max.version, max.version_name))
+            .ok_or(ApiError::NoUpdateInformation)
+    }
+
+    pub async fn get(&mut self) -> &SwVersion {
+        let expired = self
+            .last_fetch
+            .map_or(true, |time| (Utc::now() - time) > Self::CACHE_TIME);
+
+        if expired {
+            log::debug!("Firmware update information expired. Fetching..");
+        }
+
+        if expired || self.version.is_none() {
+            let version = match self.fetch_version().await {
+                Ok(version) => {
+                    log::info!("Detected newest version to be {version:?}");
+                    version
+                }
+                Err(err) => {
+                    let version = SwVersion::default();
+                    log::error!("Failed to fetch firmware changelog: {err}");
+                    log::warn!("Falling back to default version: {version:?}");
+                    version
+                }
+            };
+
+            self.last_fetch = Some(Utc::now());
+            self.version = Some(version);
+        }
+
+        self.version.as_ref().unwrap()
+    }
+}

--- a/src/z2m/mod.rs
+++ b/src/z2m/mod.rs
@@ -568,11 +568,11 @@ impl Client {
         Ok(())
     }
 
-    async fn websocket_send<'a>(
+    async fn websocket_send(
         &self,
         socket: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
         topic: &str,
-        payload: Z2mRequest<'a>,
+        payload: Z2mRequest<'_>,
     ) -> ApiResult<()> {
         let Some(uuid) = self.map.get(topic) else {
             log::trace!(


### PR DESCRIPTION
Huge improvement!

Bifrost now queries the hue firmware update servers (like the hue app does) to learn about the newest hue version number.

This branch implements all the necessary support, and spawns a new server task (background job) that tries to fetch the newest version number every 24 hours.

Once a new version number is found, the state database is automatically patched.

In my local test, the version number was successfully updated as soon as Bifrost started.

The log output looks like this:

```
bifrost[104186]: bifrost::server::updater: Firmware update information expired. Fetching..
bifrost[104186]: reqwest::connect: starting new connection: https://firmware.meethue.com/
bifrost[104186]: hyper_util::client::legacy::connect::dns: resolve; host=firmware.meethue.com
bifrost[104186]: hyper_util::client::legacy::connect::http: connecting to 34.120.72.74:443
bifrost[104186]: hyper_util::client::legacy::connect::http: connected to 34.120.72.74:443
bifrost[104186]: hyper_util::client::legacy::pool: pooling idle connection for ("https", firmware.meethue.com)
```

later that second, we see this:

```
bifrost[104186]: bifrost::model::state: Bridge device 37859e65-fdef-5965-8858-bbaef6cf47b8 on older firmware 1.60.1960149090. Updating to 1.68.0
bifrost[104186]: bifrost::model::state: Bridge device 72ca59bc-b9e3-578c-8a7d-e2ce07f3604c on older firmware 1.60.1960149090. Updating to 1.68.0
```

This all happened automatically, and the hue app worked again :+1: 