### PR TITLE
Chrivers/fix for iconnect hue

### DIFF
--- a/src/routes/api.rs
+++ b/src/routes/api.rs
@@ -274,7 +274,13 @@ async fn put_api_user_resource_id(
     }
 }
 
-pub async fn workaround() -> impl IntoResponse {
+/// This generates a workaround necessary for iConnectHue (iPhone app)
+///
+/// For some reason, iConnectHue has been observed to try the endpoint GET /api/newUser,
+/// even though this does not seem to ever have been a valid hue endpoint.
+///
+/// 2025-01-24: This response has been confirmed to work by Alexa and Peter Miller on discord.
+pub async fn workaround_iconnect_hue() -> impl IntoResponse {
     Json(json!([{"error":{"type":1,"address":"/","description":"unauthorized user"}}]))
 }
 
@@ -282,8 +288,8 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/", post(post_api))
         .route("/config", get(get_api_config))
+        .route("/newUser", get(workaround_iconnect_hue))
         .route("/:user", get(get_api_user))
-        .route("/newUser", get(workaround))
         .route("/:user/:rtype", get(get_api_user_resource))
         .route("/:user/:rtype", post(post_api_user_resource))
         .route("/:user/:rtype", put(put_api_user_resource))

--- a/src/routes/api.rs
+++ b/src/routes/api.rs
@@ -274,11 +274,16 @@ async fn put_api_user_resource_id(
     }
 }
 
+pub async fn workaround() -> impl IntoResponse {
+    Json(json!([{"error":{"type":1,"address":"/","description":"unauthorized user"}}]))
+}
+
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/", post(post_api))
         .route("/config", get(get_api_config))
         .route("/:user", get(get_api_user))
+        .route("/newUser", get(workaround))
         .route("/:user/:rtype", get(get_api_user_resource))
         .route("/:user/:rtype", post(post_api_user_resource))
         .route("/:user/:rtype", put(put_api_user_resource))


### PR DESCRIPTION
This generates a workaround necessary for iConnectHue (iPhone app)

For some reason, iConnectHue has been observed to try the endpoint GET /api/newUser,
even though this does not seem to ever have been a valid hue endpoint.

This response has been confirmed to work by Alexa and Peter Miller on discord.