### PR TITLE
Support for resuming Hue event stream

### DIFF
--- a/src/resource.rs
+++ b/src/resource.rs
@@ -128,7 +128,8 @@ impl Resources {
 
         if let Some(delta) = Self::generate_update(obj)? {
             let id_v1 = self.state.id_v1(id);
-            self.hue_event(EventBlock::update(id, id_v1, delta)?);
+            self.hue_event_stream
+                .hue_event(EventBlock::update(id, id_v1, delta)?);
         }
 
         self.state_updates.notify_one();
@@ -187,7 +188,7 @@ impl Resources {
 
         log::trace!("Send event: {evt:?}");
 
-        self.hue_event(evt);
+        self.hue_event_stream.hue_event(evt);
 
         Ok(())
     }
@@ -200,7 +201,7 @@ impl Resources {
 
         let evt = EventBlock::delete(link)?;
 
-        self.hue_event(evt);
+        self.hue_event_stream.hue_event(evt);
 
         Ok(())
     }
@@ -430,16 +431,8 @@ impl Resources {
     }
 
     #[must_use]
-    pub fn hue_channel(&self) -> Receiver<(String, EventBlock)> {
-        self.hue_event_stream.subscribe()
-    }
-
-    pub fn hue_events_sent_after_id(&self, id: &str) -> Vec<(String, EventBlock)> {
-        self.hue_event_stream.events_sent_after_id(id)
-    }
-
-    fn hue_event(&mut self, evt: EventBlock) {
-        self.hue_event_stream.hue_event(evt);
+    pub fn hue_event_stream(&self) -> &HueEventStream {
+        &self.hue_event_stream
     }
 
     #[must_use]

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -431,7 +431,7 @@ impl Resources {
     }
 
     #[must_use]
-    pub fn hue_event_stream(&self) -> &HueEventStream {
+    pub const fn hue_event_stream(&self) -> &HueEventStream {
         &self.hue_event_stream
     }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 use std::io::{Read, Write};
 use std::sync::Arc;
 
-use chrono::Utc;
 use serde_json::{json, Value};
 use tokio::sync::broadcast::{Receiver, Sender};
 use tokio::sync::Notify;
@@ -18,56 +17,21 @@ use crate::hue::api::{GroupedLightUpdate, LightUpdate, SceneUpdate, Update};
 use crate::hue::event::EventBlock;
 use crate::hue::version::SwVersion;
 use crate::model::state::{AuxData, State};
+use crate::server::hueevents::HueEventStream;
 use crate::z2m::request::ClientRequest;
-
-use std::collections::VecDeque;
-
-#[derive(Clone, Debug)]
-pub struct LastEvents {
-    inner: VecDeque<(String, EventBlock)>,
-}
-
-impl LastEvents {
-    pub fn new(capacity: usize) -> Self {
-        Self {
-            inner: VecDeque::with_capacity(capacity),
-        }
-    }
-
-    pub fn add(&mut self, id: String, evt: EventBlock) {
-        if self.inner.len() == self.inner.capacity() {
-            self.inner.pop_front();
-            self.inner.push_back((id, evt));
-            debug_assert!(self.inner.len() == self.inner.capacity());
-        } else {
-            self.inner.push_back((id, evt));
-        }
-    }
-
-    pub fn events_after_id(&self, id: &str) -> Vec<(String, EventBlock)> {
-        let mut events = self.inner.iter().skip_while(|(evt_id, _)| evt_id != id);
-        match events.next() {
-            Some(_) => events.cloned().collect(),
-            // return all events if requested event is not in buffer
-            None => self.inner.iter().cloned().collect(),
-        }
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct Resources {
     state: State,
     version: SwVersion,
     state_updates: Arc<Notify>,
-    pub hue_updates: Sender<(String, EventBlock)>,
-    pub last_hue_updates: LastEvents,
     pub z2m_updates: Sender<Arc<ClientRequest>>,
-    prev_ts: i64,
-    idx: i32,
+    hue_event_stream: HueEventStream,
 }
 
 impl Resources {
     const MAX_SCENE_ID: u32 = 100;
+    const HUE_EVENTS_BUFFER_SIZE: usize = 128;
 
     #[allow(clippy::new_without_default)]
     #[must_use]
@@ -76,11 +40,8 @@ impl Resources {
             state,
             version,
             state_updates: Arc::new(Notify::new()),
-            hue_updates: Sender::new(32),
-            last_hue_updates: LastEvents::new(32),
             z2m_updates: Sender::new(32),
-            prev_ts: Utc::now().timestamp(),
-            idx: 0,
+            hue_event_stream: HueEventStream::new(Self::HUE_EVENTS_BUFFER_SIZE),
         }
     }
 
@@ -470,30 +431,15 @@ impl Resources {
 
     #[must_use]
     pub fn hue_channel(&self) -> Receiver<(String, EventBlock)> {
-        self.hue_updates.subscribe()
+        self.hue_event_stream.subscribe()
     }
 
-    pub fn hue_events_since(&self, id: &str) -> Vec<(String, EventBlock)> {
-        self.last_hue_updates.events_after_id(id)
-    }
-
-    fn generate_event_id(&mut self) -> String {
-        let ts = Utc::now().timestamp();
-        if ts == self.prev_ts {
-            self.idx += 1;
-        } else {
-            self.idx = 0;
-            self.prev_ts = ts;
-        }
-        format!("{}:{}", ts, self.idx)
+    pub fn hue_events_sent_after_id(&self, id: &str) -> Vec<(String, EventBlock)> {
+        self.hue_event_stream.events_sent_after_id(id)
     }
 
     fn hue_event(&mut self, evt: EventBlock) {
-        let id = self.generate_event_id();
-        self.last_hue_updates.add(id.clone(), evt.clone());
-        if let Err(err) = self.hue_updates.send((id, evt)) {
-            log::trace!("Overflow on hue event pipe: {err}");
-        }
+        self.hue_event_stream.hue_event(evt);
     }
 
     #[must_use]

--- a/src/routes/eventstream.rs
+++ b/src/routes/eventstream.rs
@@ -35,8 +35,9 @@ pub async fn get_clip_v2(
     };
 
     let stream = events.map(move |e| {
-        let (evt_id, evt) = e?;
-        let json = [evt];
+        let evt = e?;
+        let evt_id = evt.id();
+        let json = [evt.block];
         log::trace!(
             "## EVENT ##: {}",
             serde_json::to_string(&json).unwrap_or_else(|_| "ERROR".to_string())

--- a/src/routes/eventstream.rs
+++ b/src/routes/eventstream.rs
@@ -17,7 +17,7 @@ pub async fn get_clip_v2(
     let hello = tokio_stream::iter([Ok(Event::default().comment("hi"))]);
     let last_event_id = headers.get("last-event-id");
 
-    let channel = state.res.lock().await.hue_channel();
+    let channel = state.res.lock().await.hue_event_stream().subscribe();
     let stream = BroadcastStream::new(channel);
     let events = match last_event_id {
         Some(id) => {
@@ -25,7 +25,8 @@ pub async fn get_clip_v2(
                 .res
                 .lock()
                 .await
-                .hue_events_sent_after_id(id.to_str().unwrap());
+                .hue_event_stream()
+                .events_sent_after_id(id.to_str().unwrap());
             stream::iter(previous_events.into_iter().map(Ok))
                 .chain(stream)
                 .boxed()

--- a/src/routes/eventstream.rs
+++ b/src/routes/eventstream.rs
@@ -25,7 +25,7 @@ pub async fn get_clip_v2(
                 .res
                 .lock()
                 .await
-                .hue_events_since(id.to_str().unwrap());
+                .hue_events_sent_after_id(id.to_str().unwrap());
             stream::iter(previous_events.into_iter().map(Ok))
                 .chain(stream)
                 .boxed()

--- a/src/routes/eventstream.rs
+++ b/src/routes/eventstream.rs
@@ -1,9 +1,9 @@
 use axum::extract::State;
+use axum::http::HeaderMap;
 use axum::response::sse::{Event, Sse};
 use axum::routing::get;
 use axum::Router;
-use chrono::Utc;
-use futures::stream::Stream;
+use futures::stream::{self, Stream};
 use futures::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 
@@ -11,29 +11,36 @@ use crate::error::ApiResult;
 use crate::server::appstate::AppState;
 
 pub async fn get_clip_v2(
+    headers: HeaderMap,
     State(state): State<AppState>,
 ) -> Sse<impl Stream<Item = ApiResult<Event>>> {
     let hello = tokio_stream::iter([Ok(Event::default().comment("hi"))]);
-
-    let mut prev_ts = Utc::now().timestamp();
-    let mut idx = 0;
+    let last_event_id = headers.get("last-event-id");
 
     let channel = state.res.lock().await.hue_channel();
+    let stream = BroadcastStream::new(channel);
+    let events = match last_event_id {
+        Some(id) => {
+            let previous_events = state
+                .res
+                .lock()
+                .await
+                .hue_events_since(id.to_str().unwrap());
+            stream::iter(previous_events.into_iter().map(Ok))
+                .chain(stream)
+                .boxed()
+        }
+        None => stream.boxed(),
+    };
 
-    let stream = BroadcastStream::new(channel).map(move |e| {
-        let json = [e?];
+    let stream = events.map(move |e| {
+        let (evt_id, evt) = e?;
+        let json = [evt];
         log::trace!(
             "## EVENT ##: {}",
             serde_json::to_string(&json).unwrap_or_else(|_| "ERROR".to_string())
         );
-        let ts = Utc::now().timestamp();
-        if ts == prev_ts {
-            idx += 1;
-        } else {
-            idx = 0;
-            prev_ts = ts;
-        }
-        Ok(Event::default().id(format!("{ts}:{idx}")).json_data(json)?)
+        Ok(Event::default().id(evt_id).json_data(json)?)
     });
 
     Sse::new(hello.chain(stream))

--- a/src/server/hueevents.rs
+++ b/src/server/hueevents.rs
@@ -1,0 +1,67 @@
+use std::collections::VecDeque;
+
+use chrono::Utc;
+use tokio::sync::broadcast::Sender;
+
+use crate::hue::event::EventBlock;
+
+#[derive(Clone, Debug)]
+pub struct HueEventStream {
+    prev_ts: i64,
+    idx: i32,
+    hue_updates: Sender<(String, EventBlock)>,
+    buffer: VecDeque<(String, EventBlock)>,
+}
+
+impl HueEventStream {
+    pub fn new(buffer_capacity: usize) -> Self {
+        Self {
+            prev_ts: Utc::now().timestamp(),
+            idx: 0,
+            hue_updates: Sender::new(32),
+            buffer: VecDeque::with_capacity(buffer_capacity),
+        }
+    }
+
+    pub fn add_to_buffer(&mut self, id: String, evt: EventBlock) {
+        if self.buffer.len() == self.buffer.capacity() {
+            self.buffer.pop_front();
+            self.buffer.push_back((id, evt));
+            debug_assert!(self.buffer.len() == self.buffer.capacity());
+        } else {
+            self.buffer.push_back((id, evt));
+        }
+    }
+
+    pub fn events_sent_after_id(&self, id: &str) -> Vec<(String, EventBlock)> {
+        let mut events = self.buffer.iter().skip_while(|(evt_id, _)| evt_id != id);
+        match events.next() {
+            Some(_) => events.cloned().collect(),
+            // return all events if requested event is not in buffer
+            None => self.buffer.iter().cloned().collect(),
+        }
+    }
+
+    pub fn hue_event(&mut self, evt: EventBlock) {
+        let id = self.generate_event_id();
+        self.add_to_buffer(id.clone(), evt.clone());
+        if let Err(err) = self.hue_updates.send((id, evt)) {
+            log::trace!("Overflow on hue event pipe: {err}");
+        }
+    }
+
+    fn generate_event_id(&mut self) -> String {
+        let ts = Utc::now().timestamp();
+        if ts == self.prev_ts {
+            self.idx += 1;
+        } else {
+            self.idx = 0;
+            self.prev_ts = ts;
+        }
+        format!("{}:{}", ts, self.idx)
+    }
+
+    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<(String, EventBlock)> {
+        self.hue_updates.subscribe()
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,7 @@
 pub mod appstate;
 pub mod banner;
 pub mod certificate;
+pub mod hueevents;
 pub mod updater;
 
 use std::fs::File;


### PR DESCRIPTION
Before this patch the Hue app goes out of sync with the current Bifrost state if changes are happening while the app is closed. For example by changing brightness in zigbee2mqtt directly. This seems to be because Hue doesn't do a full refresh when opening the app and instead relies on using Last-Event-Id to resume the event stream where it left off. 

I've therefore implemented support for storing the last 32 events in a circular buffer (actually a VecDeque) which can be sent when the client connects if it provides an event-id. I did some quick reverse engineering of the Hue bridge and it looks like it just stores the last 15 events so it's very much possible to fill this buffer with other changes and miss an entity update. Since z2m seems to be more chatty I think it makes to increase the number of stored events even more. I doubt it will affect performance and memory usage much, but I haven't looked into it.

I ended up moving event id handling down to `Resources` and instead generate it when first receiving the event. I'm not super happy about putting `prev_ts` and `idx` directly in `Resources`, so I'll gladly take suggestions on how to improve that. 