### PR TITLE
Support z2m devices with / in 'friendly name'

### DIFF
--- a/src/z2m/mod.rs
+++ b/src/z2m/mod.rs
@@ -458,7 +458,8 @@ impl Client {
     }
 
     async fn handle_device_message(&mut self, msg: RawMessage) -> ApiResult<()> {
-        if msg.topic.contains('/') {
+        if msg.topic.ends_with("/availability") {
+            // https://www.zigbee2mqtt.io/guide/usage/mqtt_topics_and_messages.html#zigbee2mqtt-friendly-name-availability
             return Ok(());
         }
 

--- a/src/z2m/mod.rs
+++ b/src/z2m/mod.rs
@@ -458,8 +458,9 @@ impl Client {
     }
 
     async fn handle_device_message(&mut self, msg: RawMessage) -> ApiResult<()> {
-        if msg.topic.ends_with("/availability") {
-            // https://www.zigbee2mqtt.io/guide/usage/mqtt_topics_and_messages.html#zigbee2mqtt-friendly-name-availability
+        if msg.topic.ends_with("/availability") || msg.topic.ends_with("/action") {
+            // availability: https://www.zigbee2mqtt.io/guide/usage/mqtt_topics_and_messages.html#zigbee2mqtt-friendly-name-availability
+            // action: https://www.home-assistant.io/integrations/device_trigger.mqtt/
             return Ok(());
         }
 


### PR DESCRIPTION
All my zigbee2mqtt devices use the namespace convention described here:
https://www.zigbee2mqtt.io/guide/usage/mqtt_topics_and_messages.html#zigbee2mqtt-friendly-name

This doesn't work in Bifrost as it ignores all device messages with a `/`. I've therefore been using a forked version where I just removed that check until I could investigate how this could be properly fixed.

Initially I thought this would require handling the weird edge cases with `device1/set/attribute` described here:
https://www.zigbee2mqtt.io/guide/usage/mqtt_topics_and_messages.html#zigbee2mqtt-friendly-name-set
But that's not relevant as all those messages are only sent to the websocket server and it seems like the only case we really need to handle is availability messages.

At least it looks like that's what the z2m frontend does:
https://github.com/nurikk/zigbee2mqtt-frontend/blob/25d88e716e4313e0643a48f32575974c0f4d1a98/src/ws-client.ts#L298-L304