### PR TITLE
Use get_software_version when patching bridge version

### DIFF
--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -126,7 +126,7 @@ impl State {
     }
 
     pub fn patch_bridge_version(&mut self, version: &SwVersion) {
-        let software_version = version.get_legacy_apiversion();
+        let software_version = version.get_software_version();
         for (uuid, value) in &mut self.res {
             let Resource::Device(dev) = value else {
                 continue;


### PR DESCRIPTION
While investigating why the Hue app kept disconnecting I noticed that the Hue bridge version reported from `/clip/v2/resource` was different. 

Real bridge: 1.69.1969060020

Bifrost: 1.69.0

Context:
```
    "product_data": {
        "certified": true,
        "manufacturer_name": "Signify Netherlands B.V.",
        "model_id": "BSB002",
        "product_archetype": "bridge_v2",
        "product_name": "Hue Bridge",
        "software_version": "1.69.1969060020"
      },
```

Changed this to use the proper version seems to fix the disconnect issue!

I'm guessing that `get_legacy_apiversion` was never meant to be used here?