### PR TITLE
Add missing ca-certificates package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM debian:bookworm-slim AS final
 
 COPY --from=build /bifrost /app/bifrost
 
-RUN apt-get -y update && apt-get install -y --no-install-recommends libssl3
+RUN apt-get -y update && apt-get install -y --no-install-recommends libssl3 ca-certificates
 
 WORKDIR /app
 


### PR DESCRIPTION
Add missing ca-certificates package in docker image, to avoid https connections failing
(such as for meethue.com version checks)