### PR TITLE
Chrivers/fix error handling

### DIFF
--- a/src/routes/clip/mod.rs
+++ b/src/routes/clip/mod.rs
@@ -22,8 +22,8 @@ pub struct V2Reply<T> {
 
 type ApiV2Result = ApiResult<Json<V2Reply<Value>>>;
 
+#[allow(clippy::unnecessary_wraps)]
 impl<T: Serialize> V2Reply<T> {
-    #[allow(clippy::unnecessary_wraps)]
     fn ok(obj: T) -> ApiV2Result {
         Ok(Json(V2Reply {
             data: vec![serde_json::to_value(obj)?],
@@ -31,7 +31,6 @@ impl<T: Serialize> V2Reply<T> {
         }))
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     fn list(data: Vec<T>) -> ApiV2Result {
         Ok(Json(V2Reply {
             data: data

--- a/src/routes/clip/mod.rs
+++ b/src/routes/clip/mod.rs
@@ -15,9 +15,14 @@ use crate::routes::extractor::Json;
 use crate::server::appstate::AppState;
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct V2Error {
+    pub description: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct V2Reply<T> {
     pub data: Vec<T>,
-    pub errors: Vec<String>,
+    pub errors: Vec<V2Error>,
 }
 
 type ApiV2Result = ApiResult<Json<V2Reply<Value>>>;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,10 +2,10 @@ use axum::response::{IntoResponse, Response};
 use axum::Router;
 use hue::error::HueError;
 use hyper::StatusCode;
-use serde_json::{json, Value};
+use serde_json::Value;
 
 use crate::error::ApiError;
-use crate::routes::clip::V2Reply;
+use crate::routes::clip::{V2Error, V2Reply};
 use crate::routes::extractor::Json;
 use crate::server::appstate::AppState;
 
@@ -21,9 +21,12 @@ impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let error_msg = format!("{self}");
         log::error!("Request failed: {error_msg}");
+
         let res = Json(V2Reply::<Value> {
             data: vec![],
-            errors: vec![json!({"description": error_msg}).to_string()],
+            errors: vec![V2Error {
+                description: error_msg,
+            }],
         });
 
         let status = match self {


### PR DESCRIPTION
Fix error handling: We accidentally double-encoded the error as json, leading to, ironically, error errors