### PR TITLE
Chrivers/better eventstream

### DIFF
--- a/crates/hue/src/api/mod.rs
+++ b/crates/hue/src/api/mod.rs
@@ -50,7 +50,7 @@ pub use stubs::{
     Taurus, Temperature, TimeZone, ZigbeeConnectivity, ZigbeeConnectivityStatus,
     ZigbeeDeviceDiscovery, Zone,
 };
-pub use update::{Update, UpdateRecord};
+pub use update::Update;
 
 use std::fmt::Debug;
 

--- a/crates/hue/src/api/update.rs
+++ b/crates/hue/src/api/update.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use uuid::Uuid;
 
 use crate::api::{
     DeviceUpdate, EntertainmentConfigurationUpdate, GroupedLightUpdate, LightUpdate, RType,
@@ -57,45 +56,6 @@ impl Update {
             Self::SmartScene(_) => RType::SmartScene,
             Self::ZigbeeDeviceDiscovery(_) => RType::ZigbeeDeviceDiscovery,
             Self::Zone(_) => RType::Zone,
-        }
-    }
-
-    #[must_use]
-    pub fn id_v1_scope(&self, id: u32, uuid: &Uuid) -> Option<String> {
-        match self {
-            Self::BehaviorInstance(_)
-            | Self::Bridge(_)
-            | Self::BridgeHome(_)
-            | Self::Geolocation(_)
-            | Self::ZigbeeDeviceDiscovery(_)
-            | Self::Zone(_) => None,
-
-            Self::Room(_) | Self::GroupedLight(_) | Self::EntertainmentConfiguration(_) => {
-                Some(format!("/groups/{id}"))
-            }
-            Self::Device(_) => Some(format!("/device/{id}")),
-            Self::Light(_) => Some(format!("/lights/{id}")),
-            Self::Scene(_) | Self::SmartScene(_) => Some(format!("/scenes/{uuid}")),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UpdateRecord {
-    pub id: Uuid,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_v1: Option<String>,
-    #[serde(flatten)]
-    pub upd: Update,
-}
-
-impl UpdateRecord {
-    #[must_use]
-    pub fn new(uuid: &Uuid, id_v1: Option<u32>, upd: Update) -> Self {
-        Self {
-            id: *uuid,
-            id_v1: id_v1.and_then(|id| upd.id_v1_scope(id, uuid)),
-            upd,
         }
     }
 }

--- a/crates/hue/src/diff.rs
+++ b/crates/hue/src/diff.rs
@@ -1,0 +1,157 @@
+use std::collections::BTreeSet;
+
+use serde_json::{Map, Value};
+
+use crate::error::{HueError, HueResult};
+
+// These properties, if present, are always included, even when unchanged
+const WHITELIST_KEYS: &[&str] = &["owner", "service_id"];
+
+pub fn event_update_diff(ma: Value, mb: Value) -> HueResult<Option<Value>> {
+    let (Value::Object(mut a), Value::Object(mut b)) = (ma, mb) else {
+        return Err(HueError::Undiffable);
+    };
+
+    let mut diff = Map::new();
+
+    // did we add any meaningful differences?
+    let mut changed = false;
+
+    // First, remove any whitelisted keys from both maps,
+    // and prefer version from "b" value
+    for key in WHITELIST_KEYS {
+        let va = a.remove(*key);
+        let vb = b.remove(*key);
+
+        changed |= va != vb;
+
+        if let Some(value) = vb.or(va) {
+            diff.insert((*key).to_string(), value);
+        }
+    }
+
+    let ka = a.keys().cloned().collect::<BTreeSet<String>>();
+    let kb = b.keys().cloned().collect::<BTreeSet<String>>();
+
+    // Keys that have appeared will be included
+    for key in &kb - &ka {
+        diff.insert(key.clone(), b.remove(&key).unwrap());
+        changed = true;
+    }
+
+    // Keys that are common will be included, if changed
+    for key in &ka & &kb {
+        if a[&key] != b[&key] {
+            diff.insert(key.clone(), b.remove(&key).unwrap());
+            changed = true;
+        }
+    }
+
+    if !changed {
+        return Ok(None);
+    }
+
+    Ok(Some(Value::Object(diff)))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::diff::event_update_diff as diff;
+
+    #[test]
+    fn test_diff_empty() {
+        let a = json!({});
+        let b = json!({});
+
+        assert_eq!(diff(a, b).unwrap(), None);
+    }
+
+    #[test]
+    fn test_diff_value_unchanged() {
+        let a = json!({"x": 42});
+        let b = json!({"x": 42});
+
+        assert_eq!(diff(a, b).unwrap(), None);
+    }
+
+    #[test]
+    fn test_diff_whitelist_unchanged() {
+        let a = json!({"owner": 42});
+        let b = json!({"owner": 42});
+
+        assert_eq!(diff(a, b).unwrap(), None);
+    }
+
+    #[test]
+    fn test_diff_value_removed() {
+        let a = json!({"x": 42});
+        let b = json!({});
+
+        assert_eq!(diff(a, b).unwrap(), None);
+    }
+
+    #[test]
+    fn test_diff_value_added() {
+        let a = json!({});
+        let b = json!({"x": 42});
+        let c = json!({"x": 42});
+
+        assert_eq!(diff(a, b).unwrap(), Some(c));
+    }
+
+    #[test]
+    fn test_diff_value_changed() {
+        let a = json!({"x": 17});
+        let b = json!({"x": 42});
+        let c = json!({"x": 42});
+
+        assert_eq!(diff(a, b).unwrap(), Some(c));
+    }
+
+    #[test]
+    fn test_diff_whitelist_removed() {
+        let a = json!({"owner": 17});
+        let b = json!({});
+        let c = json!({"owner": 17});
+
+        assert_eq!(diff(a, b).unwrap(), Some(c));
+    }
+
+    #[test]
+    fn test_diff_whitelist_added() {
+        let a = json!({});
+        let b = json!({"owner": 17});
+        let c = json!({"owner": 17});
+
+        assert_eq!(diff(a, b).unwrap(), Some(c));
+    }
+
+    #[test]
+    fn test_diff_whitelist_changed() {
+        let a = json!({"owner": 17});
+        let b = json!({"owner": 42});
+        let c = json!({"owner": 42});
+
+        assert_eq!(diff(a, b).unwrap(), Some(c));
+    }
+
+    #[test]
+    fn test_diff_value_type_changed() {
+        let a = json!({"x": 17});
+        let b = json!({"x": "foo"});
+        let c = json!({"x": "foo"});
+
+        assert_eq!(diff(a, b).unwrap(), Some(c));
+    }
+
+    #[test]
+    fn test_diff_whitelist_type_changed() {
+        let a = json!({"owner": 17});
+        let b = json!({"owner": "foo"});
+        let c = json!({"owner": "foo"});
+
+        assert_eq!(diff(a, b).unwrap(), Some(c));
+    }
+}

--- a/crates/hue/src/error.rs
+++ b/crates/hue/src/error.rs
@@ -52,6 +52,9 @@ pub enum HueError {
 
     #[error("Resource type wrong: expected {0:?} but found {1:?}")]
     WrongType(RType, RType),
+
+    #[error("Cannot generate json difference between non-map objects")]
+    Undiffable,
 }
 
 pub type HueResult<T> = Result<T, HueError>;

--- a/crates/hue/src/lib.rs
+++ b/crates/hue/src/lib.rs
@@ -6,6 +6,7 @@ pub mod colorspace;
 pub mod colortemp;
 pub mod date_format;
 pub mod devicedb;
+pub mod diff;
 pub mod error;
 pub mod event;
 pub mod flags;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -49,7 +49,7 @@ impl IntoResponse for ApiError {
                 }
                 HueError::Full(_) => StatusCode::INSUFFICIENT_STORAGE,
 
-                HueError::IOError(_) | HueError::HueZigbeeDecodeError => {
+                HueError::IOError(_) | HueError::HueZigbeeDecodeError | HueError::Undiffable => {
                     StatusCode::INTERNAL_SERVER_ERROR
                 }
             },

--- a/utils/capture-event-stream.sh
+++ b/utils/capture-event-stream.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -ue
+
+if [ $# -ne 2 ]; then
+    echo "usage: $0 <hue-key> <bridge-addr>"
+    exit 1
+fi
+
+KEY="${1}"
+IP="${2}"
+
+exec curl -N --http2 \
+     -H "Accept:text/event-stream" \
+     -s \
+     -k \
+     -H"hue-application-key: ${KEY}" \
+     "https://${IP}/eventstream/clip/v2"


### PR DESCRIPTION
When hue objects are updated, the even stream offers live updates of changed properties, to allow clients (e.g. the Hue App) to track the changes over time.

So far, our mode of these eventstream blocks have been the same as for PUT updates.

It turns out this is *almost* correct, but subtle wrong.

Instead, the event streams are based on diffing json values, and including new and changed sub-values.

Also, certain properties should *always* be included, if present. Most notably, the `.owner` field (see #76, which might be fixed by this.)

Other clients might also be affected (improved) by this (see #122)