### PR TITLE
Chrivers/ssdp upnp fix UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,7 +2469,7 @@ dependencies = [
 [[package]]
 name = "tokio-ssdp"
 version = "0.2.0"
-source = "git+https://github.com/chrivers/tokio-ssdp.git?rev=f53ea121#f53ea1213966a3dc47c8e0dfc44ca1b15fd112a9"
+source = "git+https://github.com/chrivers/tokio-ssdp.git?rev=00fc29c3#00fc29c348165e183081c7abcb7e927dcead6f81"
 dependencies = [
  "httparse",
  "httpdate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ maplit = "1.0.2"
 svc = { version = "0.1.0", path = "crates/svc" }
 z2m = { version = "0.1.0", path = "crates/z2m" }
 quick-xml = { version = "0.37.2", features = ["serialize"] }
-tokio-ssdp = { git = "https://github.com/chrivers/tokio-ssdp.git", rev = "f53ea121" }
+tokio-ssdp = { git = "https://github.com/chrivers/tokio-ssdp.git", rev = "00fc29c3" }
 native-tls = "0.2.13"
 tokio-native-tls = "0.3.1"
 tzfile = "0.1.3"

--- a/src/server/mdns.rs
+++ b/src/server/mdns.rs
@@ -43,7 +43,7 @@ impl Service for MdnsService {
         let mdns = ServiceDaemon::new()?;
         mdns.enable_interface(IpAddr::from(self.ip))?;
         let service_type = "_hue._tcp.local.";
-        let instance_name = format!("bifrost-{}", hex::encode(self.mac.bytes()));
+        let instance_name = format!("bifrost-{}", hex::encode(&self.mac.bytes()[3..]));
         let service_hostname = format!("{instance_name}.local.");
         let service_addr = self.ip.to_string();
         let service_port = 443;

--- a/src/server/ssdp.rs
+++ b/src/server/ssdp.rs
@@ -80,9 +80,9 @@ impl Service for SsdpService {
         // It's uncertain if these Device settings are valid according to the UPnP
         // spec, but they exactly match the format sent out by real hue bridges
         let server_fut = Server::new([
+            Device::raw(&usn_rootdev, "upnp:rootdevice", &location),
             Device::raw(&usn, &usn, &location),
             Device::raw(&usn, "urn:schemas-upnp-org:device:basic:1", &location),
-            Device::raw(&usn_rootdev, "upnp:rootdevice", &location),
         ])
         .extra_header("hue-bridgeid", hue::bridge_id(self.mac).to_uppercase())
         // enable workarounds to make Hue Essentials work

--- a/src/server/ssdp.rs
+++ b/src/server/ssdp.rs
@@ -47,7 +47,7 @@ impl SsdpService {
             updater,
             mac,
             ip,
-            usn: Uuid::new_v5(&Uuid::NAMESPACE_OID, &mac.bytes()),
+            usn: hue_bridge_usn(mac),
             shutdown: None,
             signal: None,
         }

--- a/src/server/ssdp.rs
+++ b/src/server/ssdp.rs
@@ -131,3 +131,19 @@ impl Service for SsdpService {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use mac_address::MacAddress;
+    use uuid::uuid;
+
+    use crate::server::ssdp::hue_bridge_usn;
+
+    #[test]
+    fn usn_generation() {
+        let expected = uuid!("2f402f80-da50-11e1-9b23-112233445566");
+        let generated = hue_bridge_usn(MacAddress::new([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]));
+
+        assert_eq!(generated, expected);
+    }
+}

--- a/src/server/ssdp.rs
+++ b/src/server/ssdp.rs
@@ -23,6 +23,22 @@ pub struct SsdpService {
     shutdown: Option<Receiver<bool>>,
 }
 
+/// Prefix used in all USN for hue bridges
+///
+/// The USN is constructed like so:
+///
+///    {PREFIX}-{MAC}
+///
+/// Example: 2f402f80-da50-11e1-9b23-112233445566
+const HUE_BRIDGE_USN_PREFIX: &str = "2f402f80-da50-11e1-9b23";
+
+#[must_use]
+pub fn hue_bridge_usn(mac: MacAddress) -> Uuid {
+    let hexmac = hex::encode(mac.bytes());
+    let uuid_str = format!("{HUE_BRIDGE_USN_PREFIX}-{hexmac}");
+    Uuid::try_parse(&uuid_str).unwrap()
+}
+
 impl SsdpService {
     #[must_use]
     pub fn new(mac: MacAddress, ip: Ipv4Addr, updater: Arc<Mutex<VersionUpdater>>) -> Self {


### PR DESCRIPTION
This change fixes ssdp/upnp discovery of Bifrost bridges.

Incorporating fixes from our forked version of `tokio-ssdp` makes Bifrost respond properly to `M-SEARCH` requests.

This makes several types of devices that were previously unable to find Bifrost, able to do so. One example is Philips Ambilight TVs.

Note: Because of a buggy implementation of the Hue protocol in those Ambilight TVs, they are still unable to use Bifrost as a streaming target. But at least they are now able to find Bifrost.