### PR TITLE
Chrivers/apiv1 error handling rework

### DIFF
--- a/crates/hue/src/error.rs
+++ b/crates/hue/src/error.rs
@@ -103,7 +103,8 @@ pub enum HueApiV1Error {
 }
 
 impl HueApiV1Error {
-    pub fn error_code(&self) -> u32 {
+    #[must_use]
+    pub const fn error_code(&self) -> u32 {
         match self {
             Self::UnauthorizedUser => 1,
             Self::BodyContainsInvalidJson => 2,

--- a/crates/hue/src/error.rs
+++ b/crates/hue/src/error.rs
@@ -55,69 +55,57 @@ pub enum HueError {
 }
 
 /// Error types for Hue Bridge v1 API
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone, Copy)]
 pub enum HueApiV1Error {
     /// Type 1
     #[error("Unauthorized")]
-    UnauthorizedUser,
+    UnauthorizedUser = 1,
 
     /// Type 2
     #[error("Body contains invalid JSON")]
-    BodyContainsInvalidJson,
+    BodyContainsInvalidJson = 2,
 
     /// Type 3
     #[error("Resource not found")]
-    ResourceNotfound,
+    ResourceNotfound = 3,
 
     /// Type 4
     #[error("Method not available for resource")]
-    MethodNotAvailableForResource,
+    MethodNotAvailableForResource = 4,
 
     /// Type 5
     #[error("Missing parameters in body")]
-    MissingParametersInBody,
+    MissingParametersInBody = 5,
 
     /// Type 6
     #[error("Parameter not available")]
-    ParameterNotAvailable,
+    ParameterNotAvailable = 6,
 
     /// Type 7
     #[error("Invalid value for parameter")]
-    InvalidValueForParameter,
+    InvalidValueForParameter = 7,
 
     /// Type 8
     #[error("Parameter not modifiable")]
-    ParameterNotModifiable,
+    ParameterNotModifiable = 8,
 
     /// Type 11
     #[error("Too many items in list")]
-    TooManyItemsInList,
+    TooManyItemsInList = 11,
 
     /// Type 12
     #[error("Portal connection is required")]
-    PortalConnectionIsRequired,
+    PortalConnectionIsRequired = 12,
 
     /// Type 901
     #[error("Internal bridge error")]
-    BridgeInternalError,
+    BridgeInternalError = 901,
 }
 
 impl HueApiV1Error {
     #[must_use]
     pub const fn error_code(&self) -> u32 {
-        match self {
-            Self::UnauthorizedUser => 1,
-            Self::BodyContainsInvalidJson => 2,
-            Self::ResourceNotfound => 3,
-            Self::MethodNotAvailableForResource => 4,
-            Self::MissingParametersInBody => 5,
-            Self::ParameterNotAvailable => 6,
-            Self::InvalidValueForParameter => 7,
-            Self::ParameterNotModifiable => 8,
-            Self::TooManyItemsInList => 11,
-            Self::PortalConnectionIsRequired => 12,
-            Self::BridgeInternalError => 901,
-        }
+        *self as u32
     }
 }
 

--- a/crates/hue/src/error.rs
+++ b/crates/hue/src/error.rs
@@ -54,4 +54,70 @@ pub enum HueError {
     Undiffable,
 }
 
+/// Error types for Hue Bridge v1 API
+#[derive(Error, Debug)]
+pub enum HueApiV1Error {
+    /// Type 1
+    #[error("Unauthorized")]
+    UnauthorizedUser,
+
+    /// Type 2
+    #[error("Body contains invalid JSON")]
+    BodyContainsInvalidJson,
+
+    /// Type 3
+    #[error("Resource not found")]
+    ResourceNotfound,
+
+    /// Type 4
+    #[error("Method not available for resource")]
+    MethodNotAvailableForResource,
+
+    /// Type 5
+    #[error("Missing parameters in body")]
+    MissingParametersInBody,
+
+    /// Type 6
+    #[error("Parameter not available")]
+    ParameterNotAvailable,
+
+    /// Type 7
+    #[error("Invalid value for parameter")]
+    InvalidValueForParameter,
+
+    /// Type 8
+    #[error("Parameter not modifiable")]
+    ParameterNotModifiable,
+
+    /// Type 11
+    #[error("Too many items in list")]
+    TooManyItemsInList,
+
+    /// Type 12
+    #[error("Portal connection is required")]
+    PortalConnectionIsRequired,
+
+    /// Type 901
+    #[error("Internal bridge error")]
+    BridgeInternalError,
+}
+
+impl HueApiV1Error {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            Self::UnauthorizedUser => 1,
+            Self::BodyContainsInvalidJson => 2,
+            Self::ResourceNotfound => 3,
+            Self::MethodNotAvailableForResource => 4,
+            Self::MissingParametersInBody => 5,
+            Self::ParameterNotAvailable => 6,
+            Self::InvalidValueForParameter => 7,
+            Self::ParameterNotModifiable => 8,
+            Self::TooManyItemsInList => 11,
+            Self::PortalConnectionIsRequired => 12,
+            Self::BridgeInternalError => 901,
+        }
+    }
+}
+
 pub type HueResult<T> = Result<T, HueError>;

--- a/crates/hue/src/error.rs
+++ b/crates/hue/src/error.rs
@@ -38,9 +38,6 @@ pub enum HueError {
     #[error("Failed to decode Hue Zigbee Update: Unknown flags {0:04x}")]
     HueZigbeeUnknownFlags(u16),
 
-    #[error("State changes not supported for: {0:?}")]
-    UpdateUnsupported(RType),
-
     #[error("Resource {0} not found")]
     NotFound(uuid::Uuid),
 

--- a/crates/hue/src/legacy_api.rs
+++ b/crates/hue/src/legacy_api.rs
@@ -117,6 +117,7 @@ pub struct NewUser {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NewUserReply {
     pub username: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clientkey: Option<String>,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,6 @@ use tokio::task::JoinError;
 
 use bifrost_api::backend::BackendRequest;
 use hue::event::EventBlock;
-use hue::legacy_api::ApiResourceType;
 use svc::error::SvcError;
 
 #[derive(Error, Debug)]
@@ -119,10 +118,6 @@ pub enum ApiError {
 
     #[error("Unexpected z2m message: {0:?}")]
     UnexpectedZ2mReply(tokio_tungstenite::tungstenite::Message),
-
-    /* hue api v1 errors */
-    #[error("Cannot create resources of type: {0:?}")]
-    V1CreateUnsupported(ApiResourceType),
 
     /* hue api v2 errors */
     #[error("Failed to get firmware version reply from update server")]

--- a/src/routes/clip/mod.rs
+++ b/src/routes/clip/mod.rs
@@ -9,7 +9,6 @@ use entertainment_configuration as ent_conf;
 
 use axum::Router;
 use axum::extract::{Path, State};
-use axum::response::IntoResponse;
 use axum::routing::{delete, get, post, put};
 use hue::api::{RType, ResourceLink};
 use serde::{Deserialize, Serialize};
@@ -51,7 +50,7 @@ impl<T: Serialize> V2Reply<T> {
     }
 }
 
-async fn get_all_resources(State(state): State<AppState>) -> impl IntoResponse {
+async fn get_all_resources(State(state): State<AppState>) -> ApiV2Result {
     let lock = state.res.lock().await;
     let res = lock.get_resources();
     drop(lock);
@@ -69,7 +68,7 @@ async fn post_resource(
     State(state): State<AppState>,
     Path(rtype): Path<RType>,
     Json(req): Json<Value>,
-) -> impl IntoResponse {
+) -> ApiV2Result {
     log::info!("POST {rtype:?}");
     log::debug!("Json data:\n{}", serde_json::to_string_pretty(&req)?);
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -43,11 +43,11 @@ impl IntoResponse for ApiError {
                 | HueError::HueEntertainmentBadHeader
                 | HueError::HueZigbeeUnknownFlags(_) => StatusCode::BAD_REQUEST,
 
-                HueError::UpdateUnsupported(_) | HueError::WrongType(_, _) => {
-                    StatusCode::NOT_ACCEPTABLE
-                }
+                HueError::UpdateUnsupported(_) => StatusCode::NOT_ACCEPTABLE,
 
-                HueError::NotFound(_) | HueError::V1NotFound(_) => StatusCode::NOT_FOUND,
+                HueError::NotFound(_) | HueError::V1NotFound(_) | HueError::WrongType(_, _) => {
+                    StatusCode::NOT_FOUND
+                }
 
                 HueError::Full(_) => StatusCode::INSUFFICIENT_STORAGE,
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,9 +1,10 @@
 use axum::Router;
 use axum::extract::DefaultBodyLimit;
 use axum::response::{IntoResponse, Response};
-use hue::error::HueError;
+use hue::error::{HueApiV1Error, HueError};
 use hyper::StatusCode;
-use serde_json::Value;
+use serde_json::{Value, json};
+use thiserror::Error;
 
 use crate::error::ApiError;
 use crate::routes::clip::{V2Error, V2Reply};
@@ -19,6 +20,82 @@ pub mod extractor;
 pub mod licenses;
 pub mod updater;
 pub mod upnp;
+
+#[derive(Error, Debug)]
+pub enum ApiV1Error {
+    #[error(transparent)]
+    ApiError(#[from] ApiError),
+
+    #[error(transparent)]
+    HueError(#[from] HueError),
+
+    #[error(transparent)]
+    SerdeJsonError(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    HueApiV1(#[from] HueApiV1Error),
+}
+
+impl ApiV1Error {
+    pub const fn http_status_code(&self) -> StatusCode {
+        // Hue bridge seems to return 200 OK in almost all cases, and use the
+        // .error field to indicate the error.
+        match self {
+            Self::ApiError(_)
+            | Self::HueError(_)
+            | Self::SerdeJsonError(_)
+            | Self::HueApiV1(
+                HueApiV1Error::UnauthorizedUser
+                | HueApiV1Error::BodyContainsInvalidJson
+                | HueApiV1Error::ResourceNotfound
+                | HueApiV1Error::MethodNotAvailableForResource
+                | HueApiV1Error::MissingParametersInBody
+                | HueApiV1Error::ParameterNotAvailable
+                | HueApiV1Error::InvalidValueForParameter
+                | HueApiV1Error::ParameterNotModifiable
+                | HueApiV1Error::TooManyItemsInList
+                | HueApiV1Error::PortalConnectionIsRequired,
+            ) => StatusCode::OK,
+
+            Self::HueApiV1(HueApiV1Error::BridgeInternalError) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    pub const fn hue_error_code(&self) -> u32 {
+        match self {
+            Self::HueError(HueError::V1NotFound(_) | HueError::WrongType(_, _)) => {
+                HueApiV1Error::ResourceNotfound.error_code()
+            }
+            Self::HueApiV1(err) => err.error_code(),
+            Self::ApiError(_) | Self::HueError(_) | Self::SerdeJsonError(_) => {
+                HueApiV1Error::BridgeInternalError.error_code()
+            }
+        }
+    }
+}
+
+type ApiV1Result<T> = Result<T, ApiV1Error>;
+
+impl IntoResponse for ApiV1Error {
+    fn into_response(self) -> Response {
+        let error_msg = format!("{self}");
+        log::error!("V1 request failed: {error_msg}");
+
+        let res = Json(json!([
+            {
+                "error": {
+                    "type": self.hue_error_code(),
+                    "address": "/",
+                    "description": format!("{self}"),
+                }
+            }
+        ]));
+
+        let status = self.http_status_code();
+
+        (status, res).into_response()
+    }
+}
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -43,8 +43,6 @@ impl IntoResponse for ApiError {
                 | HueError::HueEntertainmentBadHeader
                 | HueError::HueZigbeeUnknownFlags(_) => StatusCode::BAD_REQUEST,
 
-                HueError::UpdateUnsupported(_) => StatusCode::NOT_ACCEPTABLE,
-
                 HueError::NotFound(_) | HueError::V1NotFound(_) | HueError::WrongType(_, _) => {
                     StatusCode::NOT_FOUND
                 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -150,7 +150,6 @@ impl IntoResponse for ApiError {
             | Self::UpdateNotYetSupported(_)
             | Self::DeleteNotYetSupported(_) => StatusCode::FORBIDDEN,
 
-            Self::V1CreateUnsupported(_) => StatusCode::NOT_IMPLEMENTED,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 


### PR DESCRIPTION
Rework api V1 error handling.

Previously, any non-successful api operation on the legacy api would yield incorrect error responses. Yes, even the errors were in error!

This did not help application compatibility, but the problem is now fixed consistently.