### PR TITLE
Chrivers/service instancing

### DIFF
--- a/crates/bifrost-api/src/service.rs
+++ b/crates/bifrost-api/src/service.rs
@@ -26,12 +26,12 @@ impl Client {
         self.get("service").await
     }
 
-    pub async fn service_stop(&self, id: Uuid) -> BifrostResult<()> {
+    pub async fn service_stop(&self, id: Uuid) -> BifrostResult<Uuid> {
         self.put(&format!("service/{id}"), ServiceState::Stopped)
             .await
     }
 
-    pub async fn service_start(&self, id: Uuid) -> BifrostResult<()> {
+    pub async fn service_start(&self, id: Uuid) -> BifrostResult<Uuid> {
         self.put(&format!("service/{id}"), ServiceState::Running)
             .await
     }

--- a/crates/bifrost-api/src/service.rs
+++ b/crates/bifrost-api/src/service.rs
@@ -1,8 +1,10 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
-use svc::traits::ServiceState;
 use uuid::Uuid;
+
+use svc::serviceid::ServiceName;
+use svc::traits::ServiceState;
 
 use crate::Client;
 use crate::error::BifrostResult;
@@ -10,7 +12,7 @@ use crate::error::BifrostResult;
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Service {
     pub id: Uuid,
-    pub name: String,
+    pub name: ServiceName,
     pub state: ServiceState,
 }
 

--- a/crates/svc/src/error.rs
+++ b/crates/svc/src/error.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use thiserror::Error;
 
 use crate::manager::{ServiceEvent, SvmRequest};
-use crate::serviceid::ServiceId;
+use crate::serviceid::{ServiceId, ServiceName};
 use crate::traits::ServiceState;
 
 #[derive(Error, Debug)]
@@ -43,7 +43,7 @@ pub enum SvcError {
     ServiceNotFound(ServiceId),
 
     #[error("Service {0} already exists")]
-    ServiceAlreadyExists(String),
+    ServiceAlreadyExists(ServiceName),
 
     #[error("All services stopped")]
     Shutdown,

--- a/crates/svc/src/error.rs
+++ b/crates/svc/src/error.rs
@@ -50,6 +50,15 @@ pub enum SvcError {
 
     #[error("Service has failed")]
     ServiceFailed,
+
+    #[error("Templated service generation failed")]
+    ServiceGeneration(Box<dyn Error + Send>),
+}
+
+impl SvcError {
+    pub fn generation(err: impl Error + Send + 'static) -> Self {
+        Self::ServiceGeneration(Box::new(err))
+    }
 }
 
 #[derive(Error, Debug)]

--- a/crates/svc/src/lib.rs
+++ b/crates/svc/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod policy;
 pub mod serviceid;
+pub mod template;
 pub mod traits;
 
 #[cfg(feature = "manager")]

--- a/crates/svc/src/lib.rs
+++ b/crates/svc/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod policy;
 pub mod serviceid;
-pub mod template;
 pub mod traits;
 
 #[cfg(feature = "manager")]
@@ -11,3 +10,5 @@ pub mod manager;
 pub mod rpc;
 #[cfg(feature = "manager")]
 pub mod runservice;
+#[cfg(feature = "manager")]
+pub mod template;

--- a/crates/svc/src/policy.rs
+++ b/crates/svc/src/policy.rs
@@ -4,12 +4,14 @@ use std::time::Duration;
 #[cfg(feature = "manager")]
 use tokio::time::sleep;
 
+#[derive(Debug, Clone, Copy)]
 pub enum Retry {
     No,
     Limit(u32),
     Forever,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct Policy {
     pub retry: Retry,
     pub delay: Option<Duration>,

--- a/crates/svc/src/runservice.rs
+++ b/crates/svc/src/runservice.rs
@@ -5,7 +5,7 @@ use tokio::time::sleep;
 use uuid::Uuid;
 
 use crate::error::RunSvcError;
-use crate::manager::ServiceEvent;
+use crate::manager::{ServiceEvent, ServiceFunc};
 use crate::policy::{Policy, Retry};
 use crate::traits::{Service, ServiceRunner, ServiceState, StopResult};
 
@@ -98,6 +98,12 @@ impl<S: Service> StandardService<S> {
     pub const fn with_stop_policy(mut self, policy: Policy) -> Self {
         self.stop_policy = policy;
         self
+    }
+}
+
+impl<S: Service + 'static> StandardService<S> {
+    pub fn boxed(self) -> ServiceFunc {
+        Box::new(|a, b, c| self.run(a, b, c))
     }
 }
 

--- a/crates/svc/src/serviceid.rs
+++ b/crates/svc/src/serviceid.rs
@@ -40,7 +40,7 @@ impl Display for ServiceName {
 
 #[derive(Debug, Clone)]
 pub enum ServiceId {
-    Name(String),
+    Name(ServiceName),
     Id(Uuid),
 }
 
@@ -77,13 +77,13 @@ impl IntoServiceId for Uuid {
 
 impl IntoServiceId for String {
     fn service_id(self) -> ServiceId {
-        ServiceId::Name(self)
+        ServiceId::Name(ServiceName::from(self))
     }
 }
 
 impl IntoServiceId for &str {
     fn service_id(self) -> ServiceId {
-        ServiceId::Name(self.to_string())
+        ServiceId::Name(ServiceName::from(self))
     }
 }
 
@@ -95,7 +95,7 @@ impl From<Uuid> for ServiceId {
 
 impl From<String> for ServiceId {
     fn from(value: String) -> Self {
-        Self::Name(value)
+        value.service_id()
     }
 }
 

--- a/crates/svc/src/serviceid.rs
+++ b/crates/svc/src/serviceid.rs
@@ -1,6 +1,42 @@
 use std::fmt::{Debug, Display};
 
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ServiceName {
+    name: String,
+    instance: Option<String>,
+}
+
+impl ServiceName {
+    // suppress clippy false-positive
+    #[allow(clippy::missing_const_for_fn)]
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn instance(&self) -> Option<&str> {
+        self.instance.as_deref()
+    }
+}
+
+impl Display for ServiceName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self {
+                name,
+                instance: None,
+            } => write!(f, "{name}"),
+            Self {
+                name,
+                instance: Some(instance),
+            } => write!(f, "{name}@{instance}"),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum ServiceId {

--- a/crates/svc/src/serviceid.rs
+++ b/crates/svc/src/serviceid.rs
@@ -98,3 +98,35 @@ impl From<String> for ServiceId {
         Self::Name(value)
     }
 }
+
+impl From<String> for ServiceName {
+    fn from(value: String) -> Self {
+        if let Some((name, instance)) = value.split_once('@') {
+            Self {
+                name: name.to_string(),
+                instance: Some(instance.to_string()),
+            }
+        } else {
+            Self {
+                name: value,
+                instance: None,
+            }
+        }
+    }
+}
+
+impl From<&str> for ServiceName {
+    fn from(value: &str) -> Self {
+        if let Some((name, instance)) = value.split_once('@') {
+            Self {
+                name: name.to_string(),
+                instance: Some(instance.to_string()),
+            }
+        } else {
+            Self {
+                name: value.to_string(),
+                instance: None,
+            }
+        }
+    }
+}

--- a/crates/svc/src/serviceid.rs
+++ b/crates/svc/src/serviceid.rs
@@ -4,9 +4,16 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(from = "String", into = "String")]
 pub struct ServiceName {
     name: String,
     instance: Option<String>,
+}
+
+impl From<ServiceName> for String {
+    fn from(value: ServiceName) -> Self {
+        value.to_string()
+    }
 }
 
 impl ServiceName {

--- a/crates/svc/src/serviceid.rs
+++ b/crates/svc/src/serviceid.rs
@@ -17,6 +17,11 @@ impl From<ServiceName> for String {
 }
 
 impl ServiceName {
+    #[must_use]
+    pub const fn new(name: String, instance: Option<String>) -> Self {
+        Self { name, instance }
+    }
+
     // suppress clippy false-positive
     #[allow(clippy::missing_const_for_fn)]
     #[must_use]
@@ -49,6 +54,15 @@ impl Display for ServiceName {
 pub enum ServiceId {
     Name(ServiceName),
     Id(Uuid),
+}
+
+impl ServiceId {
+    pub fn instance(name: impl Into<String>, instance: impl Into<String>) -> Self {
+        Self::Name(ServiceName {
+            name: name.into(),
+            instance: Some(instance.into()),
+        })
+    }
 }
 
 impl Display for ServiceId {

--- a/crates/svc/src/template.rs
+++ b/crates/svc/src/template.rs
@@ -1,0 +1,70 @@
+use async_trait::async_trait;
+
+#[cfg(feature = "manager")]
+use crate::error::RunSvcError;
+use crate::error::SvcError;
+use crate::traits::{BoxDynService, Service, StopResult};
+
+#[cfg(feature = "manager")]
+pub trait ServiceTemplate: Send {
+    fn generate(&self, instance: String) -> Result<BoxDynService, SvcError>;
+}
+
+pub struct ErrorAdapter<S: Service> {
+    svc: S,
+}
+
+impl<S: Service> ErrorAdapter<S> {
+    pub const fn new(svc: S) -> Self {
+        Self { svc }
+    }
+}
+
+#[async_trait]
+impl<S: Service> Service for ErrorAdapter<S> {
+    type Error = RunSvcError;
+
+    async fn configure(&mut self) -> Result<(), Self::Error> {
+        self.svc
+            .configure()
+            .await
+            .map_err(|err| RunSvcError::ServiceError(Box::new(err)))
+    }
+
+    async fn start(&mut self) -> Result<(), Self::Error> {
+        self.svc
+            .start()
+            .await
+            .map_err(|err| RunSvcError::ServiceError(Box::new(err)))
+    }
+
+    async fn run(&mut self) -> Result<(), Self::Error> {
+        self.svc
+            .run()
+            .await
+            .map_err(|err| RunSvcError::ServiceError(Box::new(err)))
+    }
+
+    async fn stop(&mut self) -> Result<(), Self::Error> {
+        self.svc
+            .stop()
+            .await
+            .map_err(|err| RunSvcError::ServiceError(Box::new(err)))
+    }
+
+    async fn signal_stop(&mut self) -> Result<StopResult, Self::Error> {
+        self.svc
+            .signal_stop()
+            .await
+            .map_err(|err| RunSvcError::ServiceError(Box::new(err)))
+    }
+}
+
+impl<F> ServiceTemplate for F
+where
+    F: Fn(String) -> Result<BoxDynService, SvcError> + Send,
+{
+    fn generate(&self, instance: String) -> Result<BoxDynService, SvcError> {
+        self(instance)
+    }
+}

--- a/crates/svc/src/traits.rs
+++ b/crates/svc/src/traits.rs
@@ -116,19 +116,7 @@ where
 {
     type Error = E;
 
-    async fn configure(&mut self) -> Result<(), E> {
-        Ok(())
-    }
-
-    async fn start(&mut self) -> Result<(), E> {
-        Ok(())
-    }
-
     async fn run(&mut self) -> Result<(), E> {
         self.await
-    }
-
-    async fn stop(&mut self) -> Result<(), E> {
-        Ok(())
     }
 }

--- a/crates/svc/src/traits.rs
+++ b/crates/svc/src/traits.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 
 use async_trait::async_trait;
+use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "manager")]
@@ -94,6 +95,32 @@ pub trait Service: Send {
 
     async fn signal_stop(&mut self) -> Result<StopResult, Self::Error> {
         Ok(StopResult::NotSupported)
+    }
+}
+
+pub type BoxDynService = Box<dyn Service<Error = RunSvcError> + Unpin + 'static>;
+
+impl Service for BoxDynService {
+    type Error = RunSvcError;
+
+    fn run<'a: 'b, 'b>(&'a mut self) -> BoxFuture<'b, Result<(), Self::Error>> {
+        (**self).run()
+    }
+
+    fn configure<'a: 'b, 'b>(&'a mut self) -> BoxFuture<'b, Result<(), Self::Error>> {
+        (**self).configure()
+    }
+
+    fn start<'a: 'b, 'b>(&'a mut self) -> BoxFuture<'b, Result<(), Self::Error>> {
+        (**self).start()
+    }
+
+    fn stop<'a: 'b, 'b>(&'a mut self) -> BoxFuture<'b, Result<(), Self::Error>> {
+        (**self).stop()
+    }
+
+    fn signal_stop<'a: 'b, 'b>(&'a mut self) -> BoxFuture<'b, Result<StopResult, Self::Error>> {
+        (**self).signal_stop()
     }
 }
 

--- a/crates/svc/src/traits.rs
+++ b/crates/svc/src/traits.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::RunSvcError;
 #[cfg(feature = "manager")]
 use crate::manager::ServiceEvent;
+#[cfg(feature = "manager")]
 use crate::template::ErrorAdapter;
 #[cfg(feature = "manager")]
 use std::future::Future;
@@ -98,6 +99,7 @@ pub trait Service: Send {
         Ok(StopResult::NotSupported)
     }
 
+    #[cfg(feature = "manager")]
     fn boxed(self) -> BoxDynService
     where
         Self: Sized + Unpin + 'static,
@@ -106,8 +108,10 @@ pub trait Service: Send {
     }
 }
 
+#[cfg(feature = "manager")]
 pub type BoxDynService = Box<dyn Service<Error = RunSvcError> + Unpin + 'static>;
 
+#[cfg(feature = "manager")]
 impl Service for BoxDynService {
     type Error = RunSvcError;
 

--- a/crates/svc/src/traits.rs
+++ b/crates/svc/src/traits.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::RunSvcError;
 #[cfg(feature = "manager")]
 use crate::manager::ServiceEvent;
+use crate::template::ErrorAdapter;
 #[cfg(feature = "manager")]
 use std::future::Future;
 #[cfg(feature = "manager")]
@@ -95,6 +96,13 @@ pub trait Service: Send {
 
     async fn signal_stop(&mut self) -> Result<StopResult, Self::Error> {
         Ok(StopResult::NotSupported)
+    }
+
+    fn boxed(self) -> BoxDynService
+    where
+        Self: Sized + Unpin + 'static,
+    {
+        Box::new(ErrorAdapter::new(self)) as BoxDynService
     }
 }
 

--- a/crates/svc/src/traits.rs
+++ b/crates/svc/src/traits.rs
@@ -110,8 +110,9 @@ pub trait ServiceRunner {
 
 #[cfg(feature = "manager")]
 #[async_trait]
-impl<E: Error + Send + 'static, F> Service for F
+impl<E, F> Service for F
 where
+    E: Error + Send + 'static,
     F: Future<Output = Result<(), E>> + Send + Unpin,
 {
     type Error = E;

--- a/crates/svc/src/traits.rs
+++ b/crates/svc/src/traits.rs
@@ -69,10 +69,14 @@ pub enum ServiceState {
     Failed,
 }
 
+pub enum StopResult {
+    Delivered,
+    NotSupported,
+}
+
 #[async_trait]
 pub trait Service: Send {
     type Error: Error + Send + 'static;
-    const SIGNAL_STOP: bool = false;
 
     async fn configure(&mut self) -> Result<(), Self::Error> {
         Ok(())
@@ -88,8 +92,8 @@ pub trait Service: Send {
         Ok(())
     }
 
-    async fn signal_stop(&mut self) -> Result<(), Self::Error> {
-        Ok(())
+    async fn signal_stop(&mut self) -> Result<StopResult, Self::Error> {
+        Ok(StopResult::NotSupported)
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,15 +1,1 @@
 pub mod z2m;
-
-use std::sync::Arc;
-
-use async_trait::async_trait;
-use tokio::sync::broadcast::Receiver;
-
-use bifrost_api::backend::BackendRequest;
-
-use crate::error::ApiResult;
-
-#[async_trait]
-pub trait Backend {
-    async fn run_forever(self, chan: Receiver<Arc<BackendRequest>>) -> ApiResult<()>;
-}

--- a/src/backend/z2m/mod.rs
+++ b/src/backend/z2m/mod.rs
@@ -13,17 +13,19 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures::StreamExt;
 use native_tls::TlsConnector;
+use svc::traits::Service;
+use tokio::net::TcpStream;
 use tokio::select;
 use tokio::sync::broadcast::Receiver;
 use tokio::sync::{Mutex, mpsc};
-use tokio::time::sleep;
-use tokio_tungstenite::{Connector, connect_async_tls_with_config};
+use tokio_tungstenite::{
+    Connector, MaybeTlsStream, WebSocketStream, connect_async_tls_with_config,
+};
 
 use bifrost_api::backend::BackendRequest;
 use hue::api::ResourceLink;
 use z2m::update::DeviceUpdate;
 
-use crate::backend::Backend;
 use crate::backend::z2m::entertainment::EntStream;
 use crate::backend::z2m::learn::SceneLearn;
 use crate::backend::z2m::websocket::Z2mWebSocket;
@@ -46,6 +48,7 @@ pub struct Z2mBackend {
     counter: u32,
     fps: u32,
     throttle: Throttle,
+    socket: Option<WebSocketStream<MaybeTlsStream<TcpStream>>>,
 
     // for sending delayed messages over the websocket
     message_rx: mpsc::UnboundedReceiver<(String, DeviceUpdate)>,
@@ -86,6 +89,7 @@ impl Z2mBackend {
             fps,
             message_rx,
             message_tx,
+            socket: None,
             counter: 0,
         })
     }
@@ -119,8 +123,10 @@ impl Z2mBackend {
 }
 
 #[async_trait]
-impl Backend for Z2mBackend {
-    async fn run_forever(mut self, mut chan: Receiver<Arc<BackendRequest>>) -> ApiResult<()> {
+impl Service for Z2mBackend {
+    type Error = ApiError;
+
+    async fn start(&mut self) -> ApiResult<()> {
         // let's not include auth tokens in log output
         let sanitized_url = self.server.get_sanitized_url();
         let url = self.server.get_url();
@@ -154,22 +160,33 @@ impl Backend for Z2mBackend {
             None
         };
 
-        loop {
-            log::info!("[{}] Connecting to {}", self.name, &sanitized_url);
-            match connect_async_tls_with_config(url.as_str(), None, false, connector.clone()).await
-            {
-                Ok((socket, _)) => {
-                    let z2m_socket = Z2mWebSocket::new(self.name.clone(), socket);
-                    let res = self.event_loop(&mut chan, z2m_socket).await;
-                    if let Err(err) = res {
-                        log::error!("[{}] Event loop broke: {err}", self.name);
-                    }
-                }
-                Err(err) => {
-                    log::error!("[{}] Connect failed: {err:?}", self.name);
-                }
+        log::info!("[{}] Connecting to {}", self.name, &sanitized_url);
+        match connect_async_tls_with_config(url.as_str(), None, false, connector.clone()).await {
+            Ok((socket, _)) => {
+                self.socket = Some(socket);
+                Ok(())
             }
-            sleep(Duration::from_millis(2000)).await;
+            Err(err) => {
+                log::error!("[{}] Connect failed: {err:?}", self.name);
+                Err(err.into())
+            }
         }
+    }
+
+    async fn run(&mut self) -> ApiResult<()> {
+        if let Some(socket) = self.socket.take() {
+            let z2m_socket = Z2mWebSocket::new(self.name.clone(), socket);
+            let mut chan = self.state.lock().await.backend_event_stream();
+            let res = self.event_loop(&mut chan, z2m_socket).await;
+            if let Err(err) = res {
+                log::error!("[{}] Event loop broke: {err}", self.name);
+            }
+        }
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> ApiResult<()> {
+        self.socket.take();
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use std::io::Write;
 
 use svc::manager::ServiceManager;
 
-use bifrost::backend::Backend;
 use bifrost::backend::z2m::Z2mBackend;
 use bifrost::config;
 use bifrost::error::ApiResult;
@@ -115,17 +114,15 @@ async fn build_tasks(appstate: &AppState) -> ApiResult<()> {
 
     // register all z2m backends as services
     for (name, server) in &appstate.config().z2m.servers {
-        let client = Z2mBackend::new(
+        let svc = Z2mBackend::new(
             name.clone(),
             server.clone(),
             appstate.config(),
             appstate.res.clone(),
         )?;
-        let stream = appstate.res.lock().await.backend_event_stream();
         let name = format!("z2m-{name}");
-        let svc = client.run_forever(stream);
 
-        mgr.register_function(name, svc).await?;
+        mgr.register_service(name, svc).await?;
     }
 
     // finally, iterate over all services and start them

--- a/src/routes/bifrost/backend.rs
+++ b/src/routes/bifrost/backend.rs
@@ -4,7 +4,6 @@ use axum::routing::post;
 
 use bifrost_api::config::Z2mServer;
 
-use crate::backend::Backend;
 use crate::backend::z2m::Z2mBackend;
 use crate::routes::bifrost::BifrostApiResult;
 use crate::routes::extractor::Json;
@@ -20,12 +19,10 @@ async fn post_backend_z2m(
 
     let mut mgr = state.manager();
 
-    let client = Z2mBackend::new(name.clone(), server, state.config(), state.res.clone())?;
-    let stream = state.res.lock().await.backend_event_stream();
+    let svc = Z2mBackend::new(name.clone(), server, state.config(), state.res.clone())?;
     let name = format!("z2m-{name}");
-    let svc = client.run_forever(stream);
 
-    mgr.register_function(&name, svc).await?;
+    mgr.register_service(&name, svc).await?;
     mgr.start(&name).await?;
 
     Ok(Json(()))

--- a/src/routes/bifrost/service.rs
+++ b/src/routes/bifrost/service.rs
@@ -34,20 +34,20 @@ async fn put_service(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
     Json(service_state): Json<ServiceState>,
-) -> BifrostApiResult<Json<()>> {
+) -> BifrostApiResult<Json<Uuid>> {
     let mut mgr = state.manager();
 
-    match service_state {
+    let uuid = match service_state {
         ServiceState::Registered
         | ServiceState::Configured
         | ServiceState::Starting
         | ServiceState::Stopping
-        | ServiceState::Failed => {}
+        | ServiceState::Failed => mgr.resolve(id).await?,
         ServiceState::Running => mgr.start(id).await?,
         ServiceState::Stopped => mgr.stop(id).await?,
-    }
+    };
 
-    Ok(Json(()))
+    Ok(Json(uuid))
 }
 
 pub fn router() -> Router<AppState> {

--- a/src/server/entertainment.rs
+++ b/src/server/entertainment.rs
@@ -261,7 +261,6 @@ impl EntertainmentService {
 #[async_trait]
 impl Service for EntertainmentService {
     type Error = ApiError;
-    const SIGNAL_STOP: bool = false;
 
     async fn configure(&mut self) -> Result<(), Self::Error> {
         let mut bldr = SslContext::builder(SslMethod::dtls_server())?;
@@ -319,10 +318,6 @@ impl Service for EntertainmentService {
 
     async fn stop(&mut self) -> Result<(), Self::Error> {
         self.udp.take();
-        Ok(())
-    }
-
-    async fn signal_stop(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -14,7 +14,7 @@ use hyper::body::Incoming;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 
-use svc::traits::Service;
+use svc::traits::{Service, StopResult};
 
 use crate::error::{ApiError, ApiResult};
 
@@ -39,7 +39,6 @@ where
     A::Future: Send,
 {
     type Error = ApiError;
-    const SIGNAL_STOP: bool = true;
 
     async fn start(&mut self) -> Result<(), ApiError> {
         log::info!("Opening listen port on {}", self.addr);
@@ -66,9 +65,9 @@ where
         Ok(())
     }
 
-    async fn signal_stop(&mut self) -> Result<(), ApiError> {
+    async fn signal_stop(&mut self) -> Result<StopResult, ApiError> {
         self.handle.graceful_shutdown(Some(Duration::from_secs(1)));
-        Ok(())
+        Ok(StopResult::Delivered)
     }
 }
 

--- a/src/server/mdns.rs
+++ b/src/server/mdns.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use mac_address::MacAddress;
 use mdns_sd::{ServiceDaemon, ServiceInfo};
 
-use svc::traits::Service;
+use svc::traits::{Service, StopResult};
 use tokio::sync::watch::{self, Receiver, Sender};
 
 use crate::error::ApiError;
@@ -33,7 +33,6 @@ impl MdnsService {
 #[async_trait]
 impl Service for MdnsService {
     type Error = ApiError;
-    const SIGNAL_STOP: bool = true;
 
     async fn configure(&mut self) -> Result<(), Self::Error> {
         Ok(())
@@ -105,7 +104,7 @@ impl Service for MdnsService {
         Ok(())
     }
 
-    async fn signal_stop(&mut self) -> Result<(), Self::Error> {
+    async fn signal_stop(&mut self) -> Result<StopResult, Self::Error> {
         if let Some(signal) = self.signal.take() {
             log::debug!("Shutting down mdns..");
             signal
@@ -113,6 +112,6 @@ impl Service for MdnsService {
                 .map_err(|_| ApiError::service_error("Failed to send stop signal"))?;
         }
 
-        Ok(())
+        Ok(StopResult::Delivered)
     }
 }

--- a/src/server/ssdp.rs
+++ b/src/server/ssdp.rs
@@ -7,7 +7,7 @@ use tokio::sync::Mutex;
 use tokio::sync::watch::{self, Receiver, Sender};
 use tokio_ssdp::{Device, Server};
 
-use svc::traits::Service;
+use svc::traits::{Service, StopResult};
 use uuid::Uuid;
 
 use crate::error::ApiError;
@@ -57,7 +57,6 @@ impl SsdpService {
 #[async_trait]
 impl Service for SsdpService {
     type Error = ApiError;
-    const SIGNAL_STOP: bool = true;
 
     async fn configure(&mut self) -> Result<(), Self::Error> {
         Ok(())
@@ -121,14 +120,14 @@ impl Service for SsdpService {
         Ok(())
     }
 
-    async fn signal_stop(&mut self) -> Result<(), Self::Error> {
+    async fn signal_stop(&mut self) -> Result<StopResult, Self::Error> {
         if let Some(signal) = self.signal.take() {
             log::debug!("Shutting down ssdp..");
             signal
                 .send(true)
                 .map_err(|_| ApiError::service_error("Failed to send stop signal"))?;
         }
-        Ok(())
+        Ok(StopResult::Delivered)
     }
 }
 


### PR DESCRIPTION
Rework `svc` ("service") crate, to support templated services.

These are analogous to systemd template service, in which a service name can contain `@` to indicate it is a template.

In this way, instead of manually registering `foo-1`, `foo-2`, etc,
we can register `foo@`, and then start instances `1`, `2`, etc.

This makes service management cleaner and simpler, and provides a way to recognize groups
of related services.