### PR TITLE
Implement support for transition (color, brightness)

### DIFF
--- a/crates/hue/src/api/grouped_light.rs
+++ b/crates/hue/src/api/grouped_light.rs
@@ -47,6 +47,12 @@ impl GroupedLight {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GroupedLightDynamicsUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<u32>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct GroupedLightUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -59,6 +65,8 @@ pub struct GroupedLightUpdate {
     pub color_temperature: Option<ColorTemperatureUpdate>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owner: Option<ResourceLink>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dynamics: Option<GroupedLightDynamicsUpdate>,
 }
 
 impl GroupedLightUpdate {

--- a/crates/hue/src/api/grouped_light.rs
+++ b/crates/hue/src/api/grouped_light.rs
@@ -47,10 +47,25 @@ impl GroupedLight {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct GroupedLightDynamicsUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
+}
+
+impl GroupedLightDynamicsUpdate {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn with_duration(self, duration: Option<impl Into<u32>>) -> Self {
+        Self {
+            duration: duration.map(Into::into),
+            ..self
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -111,6 +126,11 @@ impl GroupedLightUpdate {
             ..self
         }
     }
+
+    #[must_use]
+    pub const fn with_dynamics(self, dynamics: Option<GroupedLightDynamicsUpdate>) -> Self {
+        Self { dynamics, ..self }
+    }
 }
 
 /* conversion from v1 api */
@@ -121,5 +141,9 @@ impl From<&ApiLightStateUpdate> for GroupedLightUpdate {
             .with_brightness(upd.bri.map(|b| f64::from(b) / 2.54))
             .with_color_xy(upd.xy.map(XY::from))
             .with_color_temperature(upd.ct)
+            .with_dynamics(
+                upd.transitiontime
+                    .map(|t| GroupedLightDynamicsUpdate::new().with_duration(Some(t * 100))),
+            )
     }
 }

--- a/crates/hue/src/api/light.rs
+++ b/crates/hue/src/api/light.rs
@@ -452,13 +452,9 @@ pub struct LightDynamics {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LightDynamicsUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<LightDynamicsStatus>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status_values: Option<Vec<LightDynamicsStatus>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub speed: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub speed_valid: Option<bool>,
+    pub duration: Option<u32>,
 }
 
 impl Default for LightDynamics {

--- a/crates/hue/src/api/light.rs
+++ b/crates/hue/src/api/light.rs
@@ -449,12 +449,27 @@ pub struct LightDynamics {
     pub speed_valid: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct LightDynamicsUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub speed: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
+}
+
+impl LightDynamicsUpdate {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn with_duration(self, duration: Option<impl Into<u32>>) -> Self {
+        Self {
+            duration: duration.map(Into::into),
+            ..self
+        }
+    }
 }
 
 impl Default for LightDynamics {
@@ -684,6 +699,11 @@ impl LightUpdate {
     pub fn with_gradient(self, gradient: Option<LightGradientUpdate>) -> Self {
         Self { gradient, ..self }
     }
+
+    #[must_use]
+    pub fn with_dynamics(self, dynamics: Option<LightDynamicsUpdate>) -> Self {
+        Self { dynamics, ..self }
+    }
 }
 
 impl From<&ApiLightStateUpdate> for LightUpdate {
@@ -694,6 +714,10 @@ impl From<&ApiLightStateUpdate> for LightUpdate {
             .with_color_temperature(upd.ct)
             .with_color_hs(upd.hs.map(Into::into))
             .with_color_xy(upd.xy.map(Into::into))
+            .with_dynamics(
+                upd.transitiontime
+                    .map(|t| LightDynamicsUpdate::new().with_duration(Some(t * 100))),
+            )
     }
 }
 

--- a/crates/hue/src/api/mod.rs
+++ b/crates/hue/src/api/mod.rs
@@ -382,7 +382,8 @@ impl<'a> V1Reply<'a> {
         self.add_option("on", upd.on)?
             .add_option("bri", upd.bri)?
             .add_option("xy", upd.xy)?
-            .add_option("ct", upd.ct)
+            .add_option("ct", upd.ct)?
+            .add_option("transitiontime", upd.transitiontime)
     }
 
     pub fn add<T: Serialize>(mut self, name: &'a str, value: T) -> HueResult<Self> {

--- a/crates/hue/src/legacy_api.rs
+++ b/crates/hue/src/legacy_api.rs
@@ -484,6 +484,8 @@ pub struct ApiLightStateUpdate {
     pub ct: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none", flatten)]
     pub hs: Option<RawHS>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transitiontime: Option<u16>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -519,6 +521,7 @@ impl From<api::SceneAction> for ApiLightStateUpdate {
             xy: action.color.map(|col| col.xy.into()),
             ct: action.color_temperature.and_then(|ct| ct.mirek),
             hs: None,
+            transitiontime: None,
         }
     }
 }

--- a/crates/z2m/src/convert.rs
+++ b/crates/z2m/src/convert.rs
@@ -190,5 +190,10 @@ impl From<&GroupedLightUpdate> for DeviceUpdate {
             .with_brightness(upd.dimming.map(|dim| dim.brightness / 100.0 * 254.0))
             .with_color_temp(upd.color_temperature.and_then(|ct| ct.mirek))
             .with_color_xy(upd.color.map(|col| col.xy))
+            .with_transition(
+                upd.dynamics
+                    .as_ref()
+                    .and_then(|d| d.duration.map(|duration| f64::from(duration) / 1000.0)),
+            )
     }
 }

--- a/crates/z2m/src/update.rs
+++ b/crates/z2m/src/update.rs
@@ -122,6 +122,11 @@ impl DeviceUpdate {
             ..self
         }
     }
+
+    #[must_use]
+    pub fn with_transition(self, transition: Option<f64>) -> Self {
+        Self { transition, ..self }
+    }
 }
 
 #[derive(Copy, Debug, Serialize, Deserialize, Clone)]

--- a/src/backend/z2m/backend_event.rs
+++ b/src/backend/z2m/backend_event.rs
@@ -96,7 +96,12 @@ impl Z2mBackend {
             .with_state(upd.on.map(|on| on.on))
             .with_brightness(upd.dimming.map(|dim| dim.brightness / 100.0 * 254.0))
             .with_color_temp(upd.color_temperature.and_then(|ct| ct.mirek))
-            .with_color_xy(upd.color.map(|col| col.xy));
+            .with_color_xy(upd.color.map(|col| col.xy))
+            .with_transition(
+                upd.dynamics
+                    .as_ref()
+                    .and_then(|d| d.duration.map(|duration| f64::from(duration) / 1000.0)),
+            );
 
         // We don't want to send gradient updates twice, but if hue
         // effects are not supported for this light, this is the best

--- a/src/backend/z2m/backend_event.rs
+++ b/src/backend/z2m/backend_event.rs
@@ -92,16 +92,23 @@ impl Z2mBackend {
         drop(lock);
 
         /* step 1: send generic light update */
+        let transition = upd
+            .dynamics
+            .as_ref()
+            .and_then(|d| d.duration.map(|duration| f64::from(duration) / 1000.0))
+            .or_else(|| {
+                if upd.dimming.is_some() || upd.color_temperature.is_some() || upd.color.is_some() {
+                    Some(0.4)
+                } else {
+                    None
+                }
+            });
         let mut payload = DeviceUpdate::default()
             .with_state(upd.on.map(|on| on.on))
             .with_brightness(upd.dimming.map(|dim| dim.brightness / 100.0 * 254.0))
             .with_color_temp(upd.color_temperature.and_then(|ct| ct.mirek))
             .with_color_xy(upd.color.map(|col| col.xy))
-            .with_transition(
-                upd.dynamics
-                    .as_ref()
-                    .and_then(|d| d.duration.map(|duration| f64::from(duration) / 1000.0)),
-            );
+            .with_transition(transition);
 
         // We don't want to send gradient updates twice, but if hue
         // effects are not supported for this light, this is the best


### PR DESCRIPTION
Transitioning between different brightness levels and color is a native zigbee feature and z2m seems to handle this very well.
Most of this PR is adding the necessary fields to the API update models (v1 and v2) and forwarding this to z2m. 

I also added a default transition time of 0.4s for brightness and color (same as the Hue bridges uses). With a short transition changing brightness/color in the Hue app looks much better than the default choppy effect.

As previously mentioned on Discord changing IKEA light colors doesn't look good, but at least now it behaves more or less the same as the Hue bridge. From a little experimenting with a IKEA LED2109G6 I think this is because the IKEA firmware doesn't support rapidly changing colors with a transition. It does support brightness nicely, and it also works with a single color transition. Doing multiple in a row (which happens easily when picking a color in the Hue app) looks bad.