### PR TITLE
Implement timed effects for Hue lights

### DIFF
--- a/crates/hue/src/api/light.rs
+++ b/crates/hue/src/api/light.rs
@@ -501,7 +501,6 @@ pub enum LightEffect {
     Cosmos,
     Sunbeam,
     Enchant,
-    Sunrise,
 }
 
 impl LightEffect {
@@ -607,11 +606,28 @@ pub struct LightEffectStatus {
     pub parameters: Option<Value>,
 }
 
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LightTimedEffect {
+    #[default]
+    NoEffect,
+    Sunrise,
+    Sunset,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct LightTimedEffects {
     pub status_values: Value,
     pub status: Value,
     pub effect_values: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct LightTimedEffectsUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effect: Option<LightTimedEffect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -642,6 +658,8 @@ pub struct LightUpdate {
     pub dynamics: Option<LightDynamicsUpdate>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub identify: Option<DeviceIdentifyUpdate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timed_effects: Option<LightTimedEffectsUpdate>,
 }
 
 impl LightUpdate {

--- a/crates/hue/src/api/light.rs
+++ b/crates/hue/src/api/light.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::ops::{AddAssign, Sub};
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use crate::api::device::DeviceIdentifyUpdate;
 use crate::api::{DeviceArchetype, Identify, Metadata, MetadataUpdate, ResourceLink, Stub};
@@ -113,9 +113,9 @@ impl Light {
             gradient: None,
             identify: Identify {},
             timed_effects: Some(LightTimedEffects {
-                status_values: json!(["no_effect", "sunrise", "sunset"]),
-                status: json!("no_effect"),
-                effect_values: json!(["no_effect", "sunrise", "sunset"]),
+                status_values: Vec::from(LightTimedEffect::ALL),
+                status: LightTimedEffect::NoEffect,
+                effect_values: Vec::from(LightTimedEffect::ALL),
             }),
             mode: LightMode::Normal,
             on: On { on: true },
@@ -615,11 +615,15 @@ pub enum LightTimedEffect {
     Sunset,
 }
 
+impl LightTimedEffect {
+    pub const ALL: [Self; 3] = [Self::NoEffect, Self::Sunrise, Self::Sunset];
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct LightTimedEffects {
-    pub status_values: Value,
-    pub status: Value,
-    pub effect_values: Value,
+    pub status_values: Vec<LightTimedEffect>,
+    pub status: LightTimedEffect,
+    pub effect_values: Vec<LightTimedEffect>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/crates/hue/src/api/mod.rs
+++ b/crates/hue/src/api/mod.rs
@@ -38,8 +38,8 @@ pub use light::{
     LightEffectValues, LightEffects, LightEffectsV2, LightEffectsV2Update, LightFunction,
     LightGradient, LightGradientMode, LightGradientPoint, LightGradientUpdate, LightMetadata,
     LightMode, LightPowerup, LightPowerupColor, LightPowerupDimming, LightPowerupOn,
-    LightPowerupPreset, LightProductData, LightSignal, LightSignaling, LightTimedEffects,
-    LightUpdate, MirekSchema, On,
+    LightPowerupPreset, LightProductData, LightSignal, LightSignaling, LightTimedEffect,
+    LightTimedEffects, LightTimedEffectsUpdate, LightUpdate, MirekSchema, On,
 };
 pub use resource::{RType, ResourceLink, ResourceRecord};
 pub use room::{Room, RoomArchetype, RoomMetadata, RoomMetadataUpdate, RoomUpdate};

--- a/crates/hue/src/effect_duration.rs
+++ b/crates/hue/src/effect_duration.rs
@@ -4,17 +4,12 @@ use crate::error::{HueError, HueResult};
 pub struct EffectDuration(pub u8);
 
 impl EffectDuration {
-    const RESOLUTION_01S_BASE: u8 = 0xFC;
-    const RESOLUTION_05S_BASE: u8 = 0xCC;
-    const RESOLUTION_15S_BASE: u8 = 0xA5;
-    const RESOLUTION_01M_BASE: u8 = 0x79;
-    const RESOLUTION_05M_BASE: u8 = 0x4A;
-
     const RESOLUTION_01S: u32 = 1; // 1s.
     const RESOLUTION_05S: u32 = 5; // 5s.
     const RESOLUTION_15S: u32 = 15; // 15s.
     const RESOLUTION_01M: u32 = 60; // 1min.
     const RESOLUTION_05M: u32 = 5 * 60; // 5min.
+
     pub const fn from_ms(milliseconds: u32) -> HueResult<Self> {
         let rounded_seconds = (milliseconds + 500) / 1000;
         Self::from_seconds(rounded_seconds)
@@ -24,20 +19,20 @@ impl EffectDuration {
     #[allow(clippy::cast_sign_loss)]
     pub const fn from_seconds(seconds: u32) -> HueResult<Self> {
         let (base, resolution) = match seconds {
-            0..60 => (Self::RESOLUTION_01S_BASE, Self::RESOLUTION_01S),
-            60..293 => (Self::RESOLUTION_05S_BASE, Self::RESOLUTION_05S),
+            0..60 => (252, Self::RESOLUTION_01S),
+            60..293 => (204, Self::RESOLUTION_05S),
             293..295 => {
                 return Ok(Self(146));
             }
-            295..878 => (Self::RESOLUTION_15S_BASE, Self::RESOLUTION_15S),
+            295..878 => (165, Self::RESOLUTION_15S),
             878..885 => {
                 return Ok(Self(107));
             }
-            885..3510 => (Self::RESOLUTION_01M_BASE, Self::RESOLUTION_01M),
+            885..3510 => (121, Self::RESOLUTION_01M),
             3510..3540 => {
                 return Ok(Self(63));
             }
-            3540..=21600 => (Self::RESOLUTION_05M_BASE, Self::RESOLUTION_05M),
+            3540..=21600 => (74, Self::RESOLUTION_05M),
             _ => {
                 return Err(HueError::EffectDurationOutOfRange(seconds));
             }

--- a/crates/hue/src/effect_duration.rs
+++ b/crates/hue/src/effect_duration.rs
@@ -18,6 +18,13 @@ const RESOLUTION_05M: u32 = 5 * 60; // 5min.
 impl EffectDuration {
     #[allow(clippy::cast_possible_truncation)]
     #[allow(clippy::cast_sign_loss)]
+    pub fn from_ms(milliseconds: u32) -> HueResult<Self> {
+        let rounded_seconds = (f64::from(milliseconds) / 1000.0).round() as u32;
+        Self::from_seconds(rounded_seconds)
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_sign_loss)]
     pub fn from_seconds(seconds: u32) -> HueResult<Self> {
         let (base, resolution) = if seconds < 60 {
             // 1min
@@ -178,7 +185,7 @@ mod tests {
 
         for (input_ms, zigbee_data) in input {
             let nearest_second: u32 = (f64::from(input_ms) / 1000.0).round() as u32;
-            let ed = EffectDuration::from_seconds(nearest_second).unwrap();
+            let ed = EffectDuration::from_ms(input_ms).unwrap();
             let zigbee_effect_duration = (zigbee_data & 0xff) as u8; // last byte is effect duration
             assert_eq!(
                 ed.0, zigbee_effect_duration,

--- a/crates/hue/src/effect_duration.rs
+++ b/crates/hue/src/effect_duration.rs
@@ -15,14 +15,14 @@ impl EffectDuration {
     const RESOLUTION_15S: u32 = 15; // 15s.
     const RESOLUTION_01M: u32 = 60; // 1min.
     const RESOLUTION_05M: u32 = 5 * 60; // 5min.
-    pub fn from_ms(milliseconds: u32) -> HueResult<Self> {
-        let rounded_seconds = (f64::from(milliseconds) / 1000.0).round() as u32;
+    pub const fn from_ms(milliseconds: u32) -> HueResult<Self> {
+        let rounded_seconds = (milliseconds + 500) / 1000;
         Self::from_seconds(rounded_seconds)
     }
 
     #[allow(clippy::cast_possible_truncation)]
     #[allow(clippy::cast_sign_loss)]
-    pub fn from_seconds(seconds: u32) -> HueResult<Self> {
+    pub const fn from_seconds(seconds: u32) -> HueResult<Self> {
         let (base, resolution) = match seconds {
             0..60 => (Self::RESOLUTION_01S_BASE, Self::RESOLUTION_01S),
             60..293 => (Self::RESOLUTION_05S_BASE, Self::RESOLUTION_05S),
@@ -43,7 +43,7 @@ impl EffectDuration {
             }
         };
         Ok(Self(
-            base - ((f64::from(seconds) / f64::from(resolution)).round() as u8),
+            base - ((seconds + (resolution / 2)) / resolution) as u8,
         ))
     }
 }

--- a/crates/hue/src/effect_duration.rs
+++ b/crates/hue/src/effect_duration.rs
@@ -19,7 +19,8 @@ impl EffectDuration {
     #[allow(clippy::cast_sign_loss)]
     pub const fn from_seconds(seconds: u32) -> HueResult<Self> {
         let (base, resolution) = match seconds {
-            0..60 => (252, Self::RESOLUTION_01S),
+            0..1 => return Ok(Self(251)),
+            1..60 => (252, Self::RESOLUTION_01S),
             60..293 => (204, Self::RESOLUTION_05S),
             293..295 => {
                 return Ok(Self(146));
@@ -328,7 +329,7 @@ mod tests {
 
     #[test]
     pub fn complete_conformance_test() {
-        let mut c = 1000;
+        let mut c = 1;
         for (x, y) in DURATION_BREAKPOINTS {
             while c <= *x {
                 assert_eq!(

--- a/crates/hue/src/effect_duration.rs
+++ b/crates/hue/src/effect_duration.rs
@@ -7,38 +7,46 @@ const RESOLUTION_01S_BASE: u8 = 0xFC;
 const RESOLUTION_05S_BASE: u8 = 0xCC;
 const RESOLUTION_15S_BASE: u8 = 0xA5;
 const RESOLUTION_01M_BASE: u8 = 0x79;
-const RESOLUTION_60M_BASE: u8 = 0x3F;
+const RESOLUTION_05M_BASE: u8 = 0x4A;
 
 const RESOLUTION_01S: u32 = 1; // 1s.
 const RESOLUTION_05S: u32 = 5; // 5s.
 const RESOLUTION_15S: u32 = 15; // 15s.
 const RESOLUTION_01M: u32 = 60; // 1min.
-// This value is just a guess. More real world testing is required
-const RESOLUTION_60M: u32 = 60 * 60; // 60min.
-
-const RESOLUTION_01S_LIMIT: u32 = 60; // 01min.
-const RESOLUTION_05S_LIMIT: u32 = 5 * 60; // 05min.
-const RESOLUTION_15S_LIMIT: u32 = 15 * 60; // 15min.
-const RESOLUTION_01M_LIMIT: u32 = 60 * 60; // 60min.
-const RESOLUTION_60M_LIMIT: u32 = 6 * 60 * 60; // 06hrs.
+const RESOLUTION_05M: u32 = 5 * 60; // 5min.
 
 impl EffectDuration {
     #[allow(clippy::cast_possible_truncation)]
-    pub const fn from_seconds(seconds: u32) -> HueResult<Self> {
-        let (base, resolution) = if seconds < RESOLUTION_01S_LIMIT {
+    #[allow(clippy::cast_sign_loss)]
+    pub fn from_seconds(seconds: u32) -> HueResult<Self> {
+        let (base, resolution) = if seconds < 60 {
+            // 1min
             (RESOLUTION_01S_BASE, RESOLUTION_01S)
-        } else if seconds < RESOLUTION_05S_LIMIT {
+        } else if seconds < 293 {
+            // ~5min
             (RESOLUTION_05S_BASE, RESOLUTION_05S)
-        } else if seconds < RESOLUTION_15S_LIMIT {
+        } else if seconds < 295 {
+            // 293 and 294 do not fit into any of the bases as they both output 145
+            return Ok(Self(146));
+        } else if seconds < 878 {
+            // ~15min
             (RESOLUTION_15S_BASE, RESOLUTION_15S)
-        } else if seconds < RESOLUTION_01M_LIMIT {
+        } else if seconds < 885 {
+            return Ok(Self(107));
+        } else if seconds < 3510 {
+            // ~60min
             (RESOLUTION_01M_BASE, RESOLUTION_01M)
-        } else if seconds < RESOLUTION_60M_LIMIT {
-            (RESOLUTION_60M_BASE, RESOLUTION_60M)
+        } else if seconds < 3540 {
+            return Ok(Self(63));
+        } else if seconds <= 6 * 60 * 60 {
+            // 06hrs
+            (RESOLUTION_05M_BASE, RESOLUTION_05M)
         } else {
             return Err(crate::error::HueError::EffectDurationOutOfRange(seconds));
         };
-        Ok(Self(base - ((seconds / resolution) as u8)))
+        Ok(Self(
+            base - ((f64::from(seconds) / f64::from(resolution)).round() as u8),
+        ))
     }
 }
 
@@ -90,5 +98,92 @@ mod tests {
     pub fn out_of_range() {
         let seconds = 10 * 60 * 60; // 10h
         assert!(EffectDuration::from_seconds(seconds).is_err());
+    }
+
+    #[test]
+    #[allow(clippy::unreadable_literal)]
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_sign_loss)]
+    pub fn timed_effect_zigbee_dump() {
+        // these values were recorded by request timed_effects to a light
+        // "timed_effects": {
+        //    "effect": "sunrise",
+        //    "duration": 3539000
+        //  }
+        let input: Vec<(u32, u64)> = vec![
+            (1500, 0xb000040009fa),
+            (2500, 0xb000040009f9),
+            (58000, 0xb000040009c2),
+            (59000, 0xb000040009c1),
+            (60000, 0xb000040009c0),
+            (61000, 0xb000040009c0),
+            (63000, 0xb000040009bf),
+            (68000, 0xb000040009be),
+            (73000, 0xb000040009bd),
+            (277000, 0xb00004000995),
+            (278000, 0xb00004000994),
+            (282000, 0xb00004000994),
+            (283000, 0xb00004000993),
+            (287000, 0xb00004000993),
+            (288000, 0xb00004000992),
+            (294000, 0xb00004000992),
+            (295000, 0xb00004000991),
+            (308000, 0xb00004000990),
+            (323000, 0xb0000400098f),
+            (338000, 0xb0000400098e),
+            (353000, 0xb0000400098d),
+            (862000, 0xb0000400096c),
+            (863000, 0xb0000400096b),
+            (864000, 0xb0000400096b),
+            (872000, 0xb0000400096b),
+            (873000, 0xb0000400096b),
+            (874000, 0xb0000400096b),
+            (875000, 0xb0000400096b),
+            (876000, 0xb0000400096b),
+            (877000, 0xb0000400096b),
+            (878000, 0xb0000400096b),
+            (879000, 0xb0000400096b),
+            (880000, 0xb0000400096b),
+            (881000, 0xb0000400096b),
+            (882000, 0xb0000400096b),
+            (883000, 0xb0000400096b),
+            (884000, 0xb0000400096b),
+            (885000, 0xb0000400096a),
+            (886000, 0xb0000400096a),
+            (887000, 0xb0000400096a),
+            (888000, 0xb0000400096a),
+            (899000, 0xb0000400096a),
+            (900000, 0xb0000400096a),
+            (901000, 0xb0000400096a),
+            (930000, 0xb00004000969),
+            (990000, 0xb00004000968),
+            (1050000, 0xb00004000967),
+            (3390000, 0xb00004000940),
+            (3450000, 0xb0000400093f),
+            (3510000, 0xb0000400093f),
+            (3539000, 0xb0000400093f),
+            (3540000, 0xb0000400093e),
+            (3599000, 0xb0000400093e),
+            (3600000, 0xb0000400093e),
+            (3601000, 0xb0000400093e),
+            (3750000, 0xb0000400093d),
+            (4050000, 0xb0000400093c),
+            (4350000, 0xb0000400093b),
+            (20850000, 0xb00004000904),
+            (21150000, 0xb00004000903),
+            (21450000, 0xb00004000902),
+            // max
+            (21600000, 0xb00004000902),
+        ];
+
+        for (input_ms, zigbee_data) in input {
+            let nearest_second: u32 = (f64::from(input_ms) / 1000.0).round() as u32;
+            let ed = EffectDuration::from_seconds(nearest_second).unwrap();
+            let zigbee_effect_duration = (zigbee_data & 0xff) as u8; // last byte is effect duration
+            assert_eq!(
+                ed.0, zigbee_effect_duration,
+                "Failed to convert {input_ms}ms ({nearest_second}s) into effect duration {zigbee_effect_duration}"
+            );
+        }
     }
 }

--- a/crates/hue/src/zigbee/composite.rs
+++ b/crates/hue/src/zigbee/composite.rs
@@ -6,6 +6,7 @@ use packed_struct::derive::{PackedStruct, PrimitiveEnum_u8};
 use packed_struct::{PackedStruct, PackedStructSlice, PrimitiveEnum};
 
 use crate::api::{LightEffect, LightGradientMode, LightTimedEffect};
+use crate::effect_duration::EffectDuration;
 use crate::error::{HueError, HueResult};
 use crate::flags::TakeFlag;
 use crate::xy::XY;
@@ -240,6 +241,11 @@ impl HueZigbeeUpdate {
     pub const fn with_effect_speed(mut self, effect_speed: u8) -> Self {
         self.effect_speed = Some(effect_speed);
         self
+    }
+
+    #[must_use]
+    pub const fn with_effect_duration(self, EffectDuration(effect_speed): EffectDuration) -> Self {
+        self.with_effect_speed(effect_speed)
     }
 }
 

--- a/crates/hue/src/zigbee/composite.rs
+++ b/crates/hue/src/zigbee/composite.rs
@@ -5,7 +5,7 @@ use byteorder::{LittleEndian as LE, ReadBytesExt, WriteBytesExt};
 use packed_struct::derive::{PackedStruct, PrimitiveEnum_u8};
 use packed_struct::{PackedStruct, PackedStructSlice, PrimitiveEnum};
 
-use crate::api::{LightEffect, LightGradientMode};
+use crate::api::{LightEffect, LightGradientMode, LightTimedEffect};
 use crate::error::{HueError, HueResult};
 use crate::flags::TakeFlag;
 use crate::xy::XY;
@@ -20,6 +20,7 @@ pub enum EffectType {
     Sparkle = 0x0a,
     Opal = 0x0b,
     Glisten = 0x0c,
+    Sunset = 0x0d,
     Underwater = 0x0e,
     Cosmos = 0x0f,
     Sunbeam = 0x10,
@@ -41,7 +42,17 @@ impl From<LightEffect> for EffectType {
             LightEffect::Cosmos => Self::Cosmos,
             LightEffect::Sunbeam => Self::Sunbeam,
             LightEffect::Enchant => Self::Enchant,
-            LightEffect::Sunrise => Self::Sunrise,
+        }
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+impl From<LightTimedEffect> for EffectType {
+    fn from(value: LightTimedEffect) -> Self {
+        match value {
+            LightTimedEffect::NoEffect => Self::NoEffect,
+            LightTimedEffect::Sunrise => Self::Sunrise,
+            LightTimedEffect::Sunset => Self::Sunset,
         }
     }
 }

--- a/doc/hue-zigbee-format.md
+++ b/doc/hue-zigbee-format.md
@@ -211,6 +211,7 @@ Size: 1 byte (specifically, [`zigbee::EffectType`])
 | `Sparkle`    | 0x0a  |
 | `Opal`       | 0x0b  |
 | `Glisten`    | 0x0c  |
+| `Sunset`     | 0x0d  |
 | `Underwater` | 0x0e  |
 | `Cosmos`     | 0x0f  |
 | `Sunbeam`    | 0x10  |

--- a/src/backend/z2m/backend_event.rs
+++ b/src/backend/z2m/backend_event.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use hue::clamp::Clamp;
+use hue::effect_duration::EffectDuration;
 use hue::zigbee::{GradientParams, GradientStyle, HueZigbeeUpdate};
 use tokio::time::sleep;
 use uuid::Uuid;
@@ -60,6 +61,18 @@ impl Z2mBackend {
             }
             if let Some(color) = &act.parameters.color {
                 hz = hz.with_color_xy(color.xy);
+            }
+        }
+
+        if let Some(act) = &upd.timed_effects {
+            if let Some(fx) = act.effect {
+                hz = hz.with_effect_type(fx.into());
+            }
+
+            if let Some(duration) = &act.duration {
+                let EffectDuration(effect_duration) =
+                    EffectDuration::from_seconds((f64::from(*duration) / 1000.0).round() as u32)?;
+                hz = hz.with_effect_speed(effect_duration);
             }
         }
 

--- a/src/backend/z2m/backend_event.rs
+++ b/src/backend/z2m/backend_event.rs
@@ -69,9 +69,8 @@ impl Z2mBackend {
                 hz = hz.with_effect_type(fx.into());
             }
 
-            if let Some(duration) = &act.duration {
-                let EffectDuration(effect_duration) =
-                    EffectDuration::from_seconds((f64::from(*duration) / 1000.0).round() as u32)?;
+            if let Some(duration) = act.duration {
+                let EffectDuration(effect_duration) = EffectDuration::from_ms(duration)?;
                 hz = hz.with_effect_speed(effect_duration);
             }
         }

--- a/src/backend/z2m/backend_event.rs
+++ b/src/backend/z2m/backend_event.rs
@@ -70,8 +70,7 @@ impl Z2mBackend {
             }
 
             if let Some(duration) = act.duration {
-                let EffectDuration(effect_duration) = EffectDuration::from_ms(duration)?;
-                hz = hz.with_effect_speed(effect_duration);
+                hz = hz.with_effect_duration(EffectDuration::from_ms(duration)?);
             }
         }
 


### PR DESCRIPTION
Using timed_effects made it much easier to inspect the zigbee message output of running the sunrise effect, so I tweaked EffectDuration to be as accurate as possible. Unfortunately that revealed some edge cases that didn't fit the existing model which made the conversion function uglier.

To test "timed effects" send a PUT request with 
```json
{
  "on": {
    "on": true
  },
  "timed_effects": {
    "effect": "sunrise",
    "duration": 60000
  }
}
```

Duration is in milliseconds. 

One thing that is missing is updating `timed_effects.status`. Since that can easily lead to concurrency issues I'll keep that out of the scope for now.


Oh, and as a bonus I added the sunset effect 🌆 
```json
{
  "on": {
    "on": true
  },
  "timed_effects": {
    "effect": "sunset",
    "duration": 60000
  }
}
```