### PR TITLE
Hue specific updates with attribute reporting

### DIFF
--- a/crates/z2m/src/api.rs
+++ b/crates/z2m/src/api.rs
@@ -121,6 +121,52 @@ pub struct DeviceRemove {
     pub id: String,
 }
 
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct DeviceRead {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub brightness: Option<String>,
+}
+
+impl DeviceRead {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn to_field_value(changed: bool) -> Option<String> {
+        // https://www.zigbee2mqtt.io/guide/usage/mqtt_topics_and_messages.html#zigbee2mqtt-friendly-name-get
+        if changed { Some("".to_string()) } else { None }
+    }
+
+    #[must_use]
+    pub fn with_state(self, on_changed: bool) -> Self {
+        Self {
+            state: Self::to_field_value(on_changed),
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub fn with_color(self, color_changed: bool) -> Self {
+        Self {
+            color: Self::to_field_value(color_changed),
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub fn with_brightness(self, brightness_changed: bool) -> Self {
+        Self {
+            brightness: Self::to_field_value(brightness_changed),
+            ..self
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DeviceRemoveResponse {
     pub id: String,

--- a/crates/z2m/src/request.rs
+++ b/crates/z2m/src/request.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::api::{DeviceRemove, GroupMemberChange, PermitJoin};
+use crate::api::{DeviceRead, DeviceRemove, GroupMemberChange, PermitJoin};
 use crate::update::DeviceUpdate;
 
 #[derive(Clone, Debug, Serialize)]
@@ -47,6 +47,9 @@ pub enum Z2mRequest<'a> {
 
     #[serde(untagged)]
     Update(&'a DeviceUpdate),
+
+    #[serde(untagged)]
+    DeviceRead(&'a DeviceRead),
 
     // same as Z2mRequest::Raw, but allows us to suppress logging for these
     #[serde(untagged)]

--- a/src/backend/z2m/websocket.rs
+++ b/src/backend/z2m/websocket.rs
@@ -6,7 +6,7 @@ use hue::zigbee::{HueZigbeeUpdate, ZigbeeMessage};
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::{self, Message};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
-use z2m::api::{DeviceRemove, GroupMemberChange, PermitJoin};
+use z2m::api::{DeviceRead, DeviceRemove, GroupMemberChange, PermitJoin};
 use z2m::request::Z2mPayload;
 use z2m::update::DeviceUpdate;
 use z2m::{api::RawMessage, request::Z2mRequest};
@@ -55,6 +55,10 @@ impl Z2mWebSocket {
                 topic: "bridge/request/device/remove".into(),
                 payload: serde_json::to_value(dev)?,
             },
+            Z2mRequest::DeviceRead(read) => RawMessage {
+                topic: format!("{topic}/get"),
+                payload: serde_json::to_value(read)?,
+            },
             _ => RawMessage {
                 topic: format!("{topic}/set"),
                 payload: serde_json::to_value(payload)?,
@@ -92,6 +96,12 @@ impl Z2mWebSocket {
 
     pub async fn send_update(&mut self, topic: &str, payload: &DeviceUpdate) -> ApiResult<()> {
         let z2mreq = Z2mRequest::Update(payload);
+
+        self.send(topic, &z2mreq).await
+    }
+
+    pub async fn send_read(&mut self, topic: &str, payload: &DeviceRead) -> ApiResult<()> {
+        let z2mreq = Z2mRequest::DeviceRead(payload);
 
         self.send(topic, &z2mreq).await
     }


### PR DESCRIPTION
The reason I started looking into this is because I found a bug with timed effects:

The following request should result in a sunrise effect which peaks at 10% brightness
```json
{
  "dimming": {
    "brightness": 10
  },
  "timed_effects": {
    "effect": "sunrise",
    "duration": 10000
  }
}
```

But since we send both standard Zigbee updates and Hue updates (when necessary) this results in the following:

```
> [server1] Sending {"topic":"kontor/desk/set","payload":{"brightness":25.400000000000002,"transition":0.4}}
> Sending hue-specific frame: b000010009f2
> [server1] Sending {"topic":"kontor/desk/set","payload":{"command":{"cluster":64515,"command":0,"payload":{"data":[176,0,1,0,9,242]}}}}
```

```
❯ echo 'b000010009f2' | cargo run --example hz-parse
| flag | on | br | mrek | (colx,coly) | effect ty. | es | gradient data                                           | grad | fade |
==================== b000010009f2
| 00b0 :    :    :      :             : Sunrise    : f2 :                                                         :      : 0001 |    FADE_SPEED | EFFECT_TYPE | EFFECT_SPEED
```

Notice the lack of brightness in the effect.

In theory I think this could lead to a race condition where the light goes to 25% brightness after 0.4s, but it seems like the effect is always ran last. 
A quick fix for this would be to add brightness to the Hue specific update under some conditions, but I wanted to see if we could get rid of the workaround (and potentially other bugs like this) by using attribute reporting.

After this PR the previous request results in this:

```
> Sending hue-specific frame: b2001a010009f2
> [server1] Sending {"topic":"kontor/desk/set","payload":{"command":{"cluster":64515,"command":0,"payload":{"data":[178,0,26,1,0,9,242]}}}}
> [server1] Sending {"topic":"kontor/desk/get","payload":{"brightness":"","color":"","state":""}}
```

```
| flag | on | br | mrek | (colx,coly) | effect ty. | es | gradient data                                           | grad | fade |
==================== b2001a010009f2
| 00b2 :    : 1a :      :             : Sunrise    : f2 :                                                         :      : 0001 |    BRIGHTNESS | FADE_SPEED | EFFECT_TYPE | EFFECT_SPEED
```

From my testing this seems to work consistently, but it does lead to double the amount of Zigbee messages when doing light updates. I don't personally notice any issues, but I guess a huge Zigbee network could have problems handling all the read requests. I think this could be handled by doing debouncing or something similar to throttle the flood of read attributes when for example selecting color. 