### PR TITLE
Reconnect to z2m websocket everytime the service fails

### DIFF
--- a/crates/svc/src/runservice.rs
+++ b/crates/svc/src/runservice.rs
@@ -66,7 +66,9 @@ impl<S: Service> StandardService<S> {
             start_policy: Policy::new()
                 .with_delay(Duration::from_secs(1))
                 .with_retry(Retry::Limit(3)),
-            run_policy: Policy::new().with_delay(Duration::from_secs(1)),
+            run_policy: Policy::new()
+                .with_retry(Retry::Forever)
+                .with_delay(Duration::from_secs(1)),
             stop_policy: Policy::new(),
         }
     }


### PR DESCRIPTION
Previously if the z2m service failed it would just stop and never restart. This can be reproduced by restarting z2m (at least that's what happens when I restart z2m in my k8s cluster). 

I don't think the z2m service change is controversial, but I also changed the default behavior for services to retry forever. I'm not sure if that can cause issues for some other services, but I haven't personally had any issues with that change.