### PR TITLE
Fix Hue Sync Color Distribution and Light Mapping

### DIFF
--- a/crates/z2m/src/api.rs
+++ b/crates/z2m/src/api.rs
@@ -88,6 +88,9 @@ pub enum Message {
 
     #[serde(rename = "bridge/response/device/ota_update/check")]
     BridgeDeviceOtaUpdateCheck(Value),
+
+    #[serde(rename = "bridge/health")]
+    BridgeHealth(BridgeHealth),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -727,4 +730,43 @@ pub enum DeviceEndpointBindingTarget {
 pub struct DeviceEndpointClusters {
     pub input: Vec<String>,
     pub output: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeHealth {
+    pub devices: Option<HashMap<String, BridgeHealthDevice>>,
+    pub mqtt: Option<BridgeHealthMqtt>,
+    pub os: Option<BridgeHealthOs>,
+    pub process: Option<BridgeHealthProcess>,
+    pub response_time: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeHealthDevice {
+    pub leave_count: Option<i64>,
+    pub messages: Option<i64>,
+    pub messages_per_sec: Option<f64>,
+    pub network_address_changes: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeHealthMqtt {
+    pub connected: bool,
+    pub published: Option<i64>,
+    pub queued: Option<i64>,
+    pub received: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeHealthOs {
+    pub load_average: Option<Vec<f64>>,
+    pub memory_percent: Option<f64>,
+    pub memory_used_mb: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeHealthProcess {
+    pub memory_percent: Option<f64>,
+    pub memory_used_mb: Option<f64>,
+    pub uptime_sec: Option<f64>,
 }

--- a/src/backend/z2m/backend_event.rs
+++ b/src/backend/z2m/backend_event.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use hue::clamp::Clamp;
 use hue::effect_duration::EffectDuration;
-use hue::zigbee::{GradientParams, GradientStyle, HueZigbeeUpdate};
+use hue::zigbee::{GradientParams, GradientStyle, HueZigbeeUpdate, LightRecordMode};
 use tokio::time::sleep;
 use uuid::Uuid;
 
@@ -374,6 +374,7 @@ impl Z2mBackend {
         let mut chans = ent.channels.clone();
 
         let mut addrs: BTreeMap<String, Vec<u16>> = BTreeMap::new();
+        let mut channels: BTreeMap<u8, (u16, LightRecordMode)> = BTreeMap::new();
         let mut targets = vec![];
         chans.sort_by_key(|c| c.channel_id);
 
@@ -400,6 +401,13 @@ impl Z2mBackend {
                     .or_default()
                     .push(segment_addr);
 
+                let mode = if ent.segments.as_ref().map_or(0, |s| s.segments.len()) > 1 {
+                    LightRecordMode::Segment
+                } else {
+                    LightRecordMode::Device
+                };
+                channels.insert(chan.channel_id as u8, (segment_addr, mode));
+
                 targets.push(topic);
             }
         }
@@ -407,7 +415,7 @@ impl Z2mBackend {
         drop(lock);
 
         if let Some(target) = targets.first() {
-            let mut es = EntStream::new(self.counter, target, addrs);
+            let mut es = EntStream::new(self.counter, target, addrs, channels);
 
             // Not even a real Philips Hue bridge uses this trick!
             //

--- a/src/backend/z2m/bridge_event.rs
+++ b/src/backend/z2m/bridge_event.rs
@@ -199,6 +199,7 @@ impl Z2mBackend {
         #[allow(unused_variables)]
         match &msg {
             Message::BridgeInfo(obj) => { /* println!("{obj:#?}"); */ }
+            Message::BridgeHealth(_obj) => { /* println!("{obj:#?}"); */ }
             Message::BridgeLogging(obj) => { /* println!("{obj:#?}"); */ }
             Message::BridgeExtensions(obj) => { /* println!("{obj:#?}"); */ }
             Message::BridgeEvent(obj) => { /* println!("{obj:#?}"); */ }

--- a/src/backend/z2m/entertainment.rs
+++ b/src/backend/z2m/entertainment.rs
@@ -17,39 +17,25 @@ pub struct EntStream {
     pub stream: EntertainmentZigbeeStream,
     pub target: String,
     pub addrs: BTreeMap<String, Vec<u16>>,
-    pub modes: Vec<(u16, LightRecordMode)>,
+    pub channels: BTreeMap<u8, (u16, LightRecordMode)>,
 }
 
 impl EntStream {
     #[must_use]
-    pub fn new(counter: u32, target: &str, addrs: BTreeMap<String, Vec<u16>>) -> Self {
-        let modes = Self::addrs_to_light_modes(&addrs);
+    pub fn new(
+        counter: u32,
+        target: &str,
+        addrs: BTreeMap<String, Vec<u16>>,
+        channels: BTreeMap<u8, (u16, LightRecordMode)>,
+    ) -> Self {
         Self {
             stream: EntertainmentZigbeeStream::new(counter),
             target: target.to_string(),
             addrs,
-            modes,
+            channels,
         }
     }
 
-    #[must_use]
-    pub fn addrs_to_light_modes(addrs: &BTreeMap<String, Vec<u16>>) -> Vec<(u16, LightRecordMode)> {
-        let mut modes = vec![];
-
-        for segments in addrs.values() {
-            let mode = if segments.len() <= 1 {
-                LightRecordMode::Device
-            } else {
-                LightRecordMode::Segment
-            };
-
-            for seg in segments {
-                modes.push((*seg, mode));
-            }
-        }
-
-        modes
-    }
 
     #[must_use]
     pub fn z2m_set_entertainment_brightness(brightness: u8) -> Z2mRequest<'static> {
@@ -75,11 +61,11 @@ impl EntStream {
                     let (xy, bright) = light.rgb.to_xy();
 
                     let brightness = (bright / 255.0 * 2047.0).clamp(1.0, 2047.0) as u16;
-                    let (chan, mode) = self.modes[light.channel as usize % self.modes.len()];
-                    let raw = xy.to_quant();
-                    let lrec = HueEntFrameLightRecord::new(chan, brightness, mode, raw);
-
-                    blks.push(lrec);
+                    if let Some((chan, mode)) = self.channels.get(&light.channel) {
+                        let raw = xy.to_quant();
+                        let lrec = HueEntFrameLightRecord::new(*chan, brightness, *mode, raw);
+                        blks.push(lrec);
+                    }
                 }
             }
             HueStreamLightsV2::Xy(xy) => {
@@ -87,11 +73,11 @@ impl EntStream {
                     let (xy, bright) = light.xy.to_xy();
 
                     let brightness = (bright / 255.0 * 2047.0).clamp(1.0, 2047.0) as u16;
-                    let (chan, mode) = self.modes[light.channel as usize % self.modes.len()];
-                    let raw = xy.to_quant();
-                    let lrec = HueEntFrameLightRecord::new(chan, brightness, mode, raw);
-
-                    blks.push(lrec);
+                    if let Some((chan, mode)) = self.channels.get(&light.channel) {
+                        let raw = xy.to_quant();
+                        let lrec = HueEntFrameLightRecord::new(*chan, brightness, *mode, raw);
+                        blks.push(lrec);
+                    }
                 }
             }
         }
@@ -101,7 +87,7 @@ impl EntStream {
 
     pub async fn start_stream(&mut self, z2mws: &mut Z2mWebSocket) -> ApiResult<()> {
         log::debug!("Entertainment addrs: {:#?}", &self.addrs);
-        log::debug!("Entertainment modes: {:#?}", &self.modes);
+        log::debug!("Entertainment channels: {:#?}", &self.channels);
         for (dev, segments) in &self.addrs {
             let z2mreq = Self::z2m_set_entertainment_brightness(0xFE);
             z2mws.send(dev, &z2mreq).await?;

--- a/src/routes/bifrost/websocket.rs
+++ b/src/routes/bifrost/websocket.rs
@@ -94,7 +94,10 @@ impl WebSocketTask {
 
         loop {
             let reply = select! {
-                Some(msg) = self.ws.recv() => self.handle_websocket_message(&msg?),
+                msg = self.ws.recv() => match msg {
+                    Some(msg) => self.handle_websocket_message(&msg?),
+                    None => return Ok(()),
+                },
                 backend_event = backend_events.recv() => self.handle_backend_event(&backend_event?),
                 service_event = svc_events.recv() => self.handle_service_event(service_event).await,
                 hue_event = hue_events.recv() => self.handle_hue_event(hue_event?),

--- a/src/routes/clip/entertainment_configuration.rs
+++ b/src/routes/clip/entertainment_configuration.rs
@@ -128,28 +128,31 @@ fn make_channels(
         let ent: &Entertainment = lock.get(&location.service)?;
 
         if let Some(segs) = &ent.segments {
-            for index in 0..segs.segments.len() {
-                channels.push(EntertainmentConfigurationChannels {
-                    channel_id,
-                    position: POSITIONS[index % POSITIONS.len()].clone(),
-                    members: vec![EntertainmentConfigurationStreamMembers {
-                        service: location.service,
-                        index: u16::try_from(index)?,
-                    }],
-                });
-                channel_id += 1;
+            if segs.segments.len() > 1 {
+                for index in 0..segs.segments.len() {
+                    channels.push(EntertainmentConfigurationChannels {
+                        channel_id,
+                        position: POSITIONS[index % POSITIONS.len()].clone(),
+                        members: vec![EntertainmentConfigurationStreamMembers {
+                            service: location.service,
+                            index: u16::try_from(index)?,
+                        }],
+                    });
+                    channel_id += 1;
+                }
+                continue;
             }
-        } else {
-            channels.push(EntertainmentConfigurationChannels {
-                channel_id,
-                position: pos.clone(),
-                members: vec![EntertainmentConfigurationStreamMembers {
-                    service: location.service,
-                    index: 0,
-                }],
-            });
-            channel_id += 1;
         }
+
+        channels.push(EntertainmentConfigurationChannels {
+            channel_id,
+            position: pos.clone(),
+            members: vec![EntertainmentConfigurationStreamMembers {
+                service: location.service,
+                index: 0,
+            }],
+        });
+        channel_id += 1;
     }
 
     Ok(channels)


### PR DESCRIPTION
This PR resolves two critical issues in the Hue Entertainment streaming implementation that caused incorrect color distribution across bulbs in an entertainment zone.

### Fixed Issues:
1. **"Bottom Left" Color Persistence**: Standard bulbs were incorrectly being identified as multi-segment devices. This triggered a fallback to a hard-coded list of segment positions, the first of which was "Bottom Left". Consequently, every bulb in the zone was reporting the same position to the Sync app, leading to identical color data for all lights.
2. **Alphabetical Mapping Scramble**: The backend was mapping incoming color channels to Zigbee devices based on the alphabetical order of their friendly names. This resulted in a disconnect between the Sync app's channel IDs and the actual physical bulbs.

### Changes:
- **`src/routes/clip/entertainment_configuration.rs`**: Updated `make_channels` to verify the segment count. Standard bulbs (1 segment) now correctly preserve their user-defined positions from the Hue app.
- **`src/backend/z2m/backend_event.rs`**: Refactored the entertainment start sequence to build an explicit mapping of `channel_id` to Zigbee network addresses.
- **`src/backend/z2m/entertainment.rs`**: Updated `EntStream` to utilize the new channel-based mapping, ensuring color data is routed correctly even if device names are changed or reordered.