### PR TITLE
fix(z2m): add missing DeviceEffect variants and catch-all

### DIFF
--- a/crates/z2m/src/update.rs
+++ b/crates/z2m/src/update.rs
@@ -245,13 +245,20 @@ impl From<DeviceState> for On {
     }
 }
 
-#[derive(Copy, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DeviceEffect {
+    None,
+    Colorloop,
+    Candle,
+    Fireplace,
     Blink,
     Breathe,
     Okay,
     ChannelChange,
     FinishEffect,
     StopEffect,
+    StopHueEffect,
+    #[serde(other)]
+    Other,
 }


### PR DESCRIPTION
Adds `None` and `Colorloop` variants to `DeviceEffect` to prevent Z2M update parsing errors. Also adds `#[serde(other)] Other` fallback to safely handle unknown or future effect strings from Z2M.